### PR TITLE
fixes suffix for numbers

### DIFF
--- a/src/lib/nifreader.nim
+++ b/src/lib/nifreader.nim
@@ -231,6 +231,11 @@ proc handleNumber(r: var Reader; result: var Token) =
           inc p
           inc result.s.len
 
+      if p < eof and ^p == 'u':
+        result.tk = UIntLit
+        inc p
+        # ignore the suffix 'u'
+
 proc handleLineInfo(r: var Reader; result: var Token) =
   useCpuRegisters:
     var col = 0

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -187,11 +187,6 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos) =
   of ConvC: typedUnOp ""
   of SufC:
     let (value, suffix) = sons2(t, n)
-    case t[value].kind
-    of StrLit:
-      c.add makeCString(c.m.lits.strings[t[value].litId])
-    else:
-      assert c.m.lits.strings[t[suffix].litId].startsWith('u')
-      genUIntLit c, t[value].litId
+    genx(c, t, value)
   else:
     genLvalue c, t, n


### PR DESCRIPTION
> Unsigned numbers always have a `u` suffix.

Otherwise the trailing `u` is parsed as an ident.