### PR TITLE
fixes typedBinOp gen

### DIFF
--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -17,9 +17,11 @@ template typedBinOp(opr) =
   c.add ParLe
   genType c, t, typ
   c.add ParRi
+  c.add ParLe
   genx c, t, a
   c.add opr
   genx c, t, b
+  c.add ParRi
   c.add ParRi
 
 template cmpOp(opr) =

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -45,6 +45,9 @@
     (var :z . (f +32 .) (suf +12.5 "f32"))
     (var :z1 . (f +64 .) (suf +12.5 "f64"))
     (var :z2 . (ptr (c +8 .)) (cast (ptr (c +8 .)) (suf "hello" "r")))
+
+    (var :add2.m . (i +32 .) (add (i +32 .) +214 +21))
     (ret +0)
   ))
 )
+


### PR DESCRIPTION
(add i8 4 5)
before
```nim
(NI8)4 + 5
```
After

```nim
(NI8)(4 + 5)
```