### PR TITLE
use nimPreviewSlimSystem everywhere, workarounds for 2.0 compiler

### DIFF
--- a/src/config.nims
+++ b/src/config.nims
@@ -1,0 +1,1 @@
+--define:nimPreviewSlimSystem

--- a/src/gear2/bridge.nim
+++ b/src/gear2/bridge.nim
@@ -9,7 +9,7 @@
 when defined(nifBench):
   import std / monotimes
 
-import std / [strutils]
+import std / [strutils, assertions, syncio]
 
 import compiler / [
   ast, options, pathutils, renderer, lineinfos,

--- a/src/gear2/gear2.nim
+++ b/src/gear2/gear2.nim
@@ -1,7 +1,7 @@
 when not defined(nimcore):
   {.error: "nimcore MUST be defined for Nim's core tooling".}
 
-import std / [os, times, parseopt]
+import std / [os, times, parseopt, syncio]
 import compiler / [
   llstream, ast, options, msgs, condsyms, idents, platform, reorder,
   modules, pipelineutils, pipelines, packages, modulegraphs, lineinfos, pathutils,

--- a/src/lib/keymatcher.nim
+++ b/src/lib/keymatcher.nim
@@ -13,7 +13,7 @@
 # Every string of length > position for which s[position] <= char is in one
 # set else it is in the other set.
 
-import std / [macros]
+import std / [macros, assertions]
 
 import stringviews
 

--- a/src/lib/nifbuilder.nim
+++ b/src/lib/nifbuilder.nim
@@ -6,6 +6,8 @@
 
 ## Support code for generating NIF code.
 
+import std / [assertions, syncio, formatfloat]
+
 type
   Mode = enum
     UsesMem, UsesFile

--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -6,6 +6,7 @@
 
 ## Cursors into token streams. Suprisingly effective even for more complex algorithms.
 
+import std / assertions
 import nifstreams, lineinfos
 
 type

--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -72,9 +72,14 @@ type
     len, cap, readers: int
 
 proc `=copy`(dest: var TokenBuf; src: TokenBuf) {.error.}
-proc `=destroy`(dest: TokenBuf) {.inline.} =
-  #assert dest.readers == 0, "TokenBuf still in use by some reader"
-  if dest.data != nil: dealloc(dest.data)
+when defined(nimAllowNonVarDestructor):
+  proc `=destroy`(dest: TokenBuf) {.inline.} =
+    #assert dest.readers == 0, "TokenBuf still in use by some reader"
+    if dest.data != nil: dealloc(dest.data)
+else:
+  proc `=destroy`(dest: var TokenBuf) {.inline.} =
+    #assert dest.readers == 0, "TokenBuf still in use by some reader"
+    if dest.data != nil: dealloc(dest.data)
 
 proc isMutable(b: TokenBuf): bool {.inline.} = b.cap >= 0
 

--- a/src/lib/nifindexes.nim
+++ b/src/lib/nifindexes.nim
@@ -6,7 +6,7 @@
 
 ## Create an index file for a NIF file.
 
-import std / [os, tables]
+import std / [os, tables, assertions, syncio]
 import bitabs, lineinfos, nifreader, nifstreams, nifcursors
 
 proc registerTag(tag: string): TagId = pool.tags.getOrIncl(tag)

--- a/src/lib/nifreader.nim
+++ b/src/lib/nifreader.nim
@@ -6,7 +6,7 @@
 
 ## High performance ("zero copies") NIF file reader.
 
-import std / [memfiles, tables, parseutils]
+import std / [memfiles, tables, parseutils, assertions]
 import stringviews
 
 const

--- a/src/lib/packedtrees.nim
+++ b/src/lib/packedtrees.nim
@@ -168,7 +168,7 @@ proc firstSon*[E](tree: PackedTree[E]; n: NodePos): NodePos {.inline.} =
 
 template check[E](a: int; tree: PackedTree[E]; n: NodePos) =
   bind rawSpan # bug in csources_v2 nim
-  assert a < int(n) + tree[n].rawSpan
+  assert a < int(n) + rawSpan(tree[n])
 
 proc kind*[E](tree: PackedTree[E]; n: NodePos): E {.inline.} =
   tree.nodes[n.int].kind

--- a/src/lib/packedtrees.nim
+++ b/src/lib/packedtrees.nim
@@ -167,6 +167,7 @@ proc firstSon*[E](tree: PackedTree[E]; n: NodePos): NodePos {.inline.} =
   NodePos(n.int+1)
 
 template check[E](a: int; tree: PackedTree[E]; n: NodePos) =
+  bind rawSpan # bug in csources_v2 nim
   assert a < int(n) + tree[n].rawSpan
 
 proc kind*[E](tree: PackedTree[E]; n: NodePos): E {.inline.} =

--- a/src/nifc/amd64/emitter.nim
+++ b/src/nifc/amd64/emitter.nim
@@ -9,6 +9,7 @@
 
 ## Emits real ASM code from the NIF based format.
 
+import std / [assertions, syncio, formatfloat]
 import nifreader, nifstreams, nifcursors, bitabs, lineinfos
 from strutils import escape
 

--- a/src/nifc/amd64/machine.nim
+++ b/src/nifc/amd64/machine.nim
@@ -7,6 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
+import std / assertions
 import ".." / nifc_model
 import ".." / native / slots
 

--- a/src/nifc/makefile.nim
+++ b/src/nifc/makefile.nim
@@ -1,4 +1,4 @@
-import std/[os, strformat, tables]
+import std/[os, strformat, tables, syncio]
 import noptions
 
 proc generateMakefileForFiles(s: State, files: seq[string],

--- a/src/nifc/nifc.nim
+++ b/src/nifc/nifc.nim
@@ -9,7 +9,7 @@
 
 ## NIFC driver program.
 
-import std / [parseopt, strutils, os, osproc, tables]
+import std / [parseopt, strutils, os, osproc, tables, assertions, syncio]
 import codegen, makefile, noptions
 import preasm / genpreasm
 

--- a/src/nifc/nifc_model.nim
+++ b/src/nifc/nifc_model.nim
@@ -6,7 +6,7 @@
 
 ## Parse NIF into a packed tree representation.
 
-import std / [hashes, tables]
+import std / [hashes, tables, assertions]
 import "../lib" / [bitabs, lineinfos, stringviews, packedtrees, nifreader, keymatcher,
   nifbuilder]
 import noptions

--- a/src/nifc/typenav.nim
+++ b/src/nifc/typenav.nim
@@ -6,7 +6,7 @@
 
 ## A type navigator can recompute the type of an expression.
 
-import std / [strutils, tables]
+import std / [strutils, tables, assertions]
 import bitabs, packedtrees
 
 import nifc_model

--- a/src/nifgram/nifgram.nim
+++ b/src/nifgram/nifgram.nim
@@ -8,7 +8,7 @@
 ## that is also in NIF notation.
 ## See nifc/nifc_grammar.nif for a real world example.
 
-import std / [strutils, tables, sets]
+import std / [strutils, tables, sets, assertions, syncio]
 import "../lib" / [stringviews, nifreader]
 
 type

--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -9,6 +9,8 @@
 when defined(nifBench):
   import std / monotimes
 
+import std / [assertions, syncio]
+
 import compiler / [
   ast, options, pathutils, renderer, lineinfos,
   parser, llstream, idents, msgs]

--- a/src/nifler/emitter.nim
+++ b/src/nifler/emitter.nim
@@ -6,6 +6,8 @@
 
 ## Module that helps to emit NIF code, somewhat nicely formatted.
 
+import std / formatfloat
+
 type
   Emitter* = object # state we need in order to do some formatting
     minified*: bool # produce minified code

--- a/src/nifler/nifler.nim
+++ b/src/nifler/nifler.nim
@@ -7,7 +7,7 @@
 ## Nifler is a simple tool that parses Nim code and outputs NIF code.
 ## No semantic checking is done and no symbol lookups are performed.
 
-import std / [parseopt, strutils, os]
+import std / [parseopt, strutils, os, syncio, assertions]
 import emitter, bridge
 
 const

--- a/src/xelim/xelim.nim
+++ b/src/xelim/xelim.nim
@@ -9,7 +9,7 @@
 
 ## xelim driver program.
 
-import std / [parseopt, strutils, os]
+import std / [parseopt, strutils, os, assertions]
 import xelim_transformer
 
 const

--- a/src/xelim/xelim_model.nim
+++ b/src/xelim/xelim_model.nim
@@ -6,7 +6,7 @@
 
 ## Parse NIF into a packed tree representation.
 
-import std / [hashes, tables]
+import std / [hashes, tables, assertions]
 import "../lib" / [bitabs, lineinfos, stringviews, packedtrees, nifreader, keymatcher,
   nifbuilder]
 

--- a/src/xelim/xelim_transformer.nim
+++ b/src/xelim/xelim_transformer.nim
@@ -3,6 +3,7 @@
 ## `let x = if cond: 3 else: 4` into
 ## `let tmp; if cond: tmp = 3 else: temp = 4; let x = tmp`
 
+import std / [assertions, syncio]
 import ".." / lib / [packedtrees, lineinfos, bitabs]
 import xelim_model, xelim_typenav
 

--- a/src/xelim/xelim_typenav.nim
+++ b/src/xelim/xelim_typenav.nim
@@ -6,7 +6,7 @@
 
 ## A type navigator can recompute the type of an expression.
 
-import std / tables
+import std / [tables, assertions]
 import "../lib" / [bitabs, packedtrees]
 
 import xelim_model


### PR DESCRIPTION
Compiler codebase has `nimPreviewSlimSystem` on, do the same here and without conditions since it's unlikely we will have to compile nif with a < 2.0 compiler. It's easy to make conditional if we do though.

Workarounds for the csources_v2 (2.0) compiler are also added for bootstrapping Nim. These are for the lack of non-var destructors and a template resolution bug with dot fields in `packedtrees`. `ensureMove` also does not exist on 2.0 but this can also be fixed by making `ensureMove` a no-op on older versions in the Nim repo standard library for just bootstrapping.

Tested at https://github.com/nim-lang/Nim/pull/24262.