### PR TITLE
only define non-var destructor in arc/orc

### DIFF
--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -72,7 +72,7 @@ type
     len, cap, readers: int
 
 proc `=copy`(dest: var TokenBuf; src: TokenBuf) {.error.}
-when defined(nimAllowNonVarDestructor):
+when defined(nimAllowNonVarDestructor) and defined(gcDestructors):
   proc `=destroy`(dest: TokenBuf) {.inline.} =
     #assert dest.readers == 0, "TokenBuf still in use by some reader"
     if dest.data != nil: dealloc(dest.data)


### PR DESCRIPTION
Another 2.0 compatibillity fix following up #97, encountered in https://github.com/nim-lang/Nim/pull/24262 when booting with refc.