### PR TITLE
define required IL64 macro for large negative int64

### DIFF
--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -155,5 +155,11 @@ typedef NU8 NU;
 #  endif
 #endif
 
+#if defined(__GNUC__) || defined(_MSC_VER)
+#  define IL64(x) x##LL
+#else /* works only without LL */
+#  define IL64(x) ((NI64)x)
+#endif
+
 """
 

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -140,6 +140,13 @@
     (var :x3.m . (f +64) (nan))
   ))
 
+  (proc :foo.intminmax . . . (stmts
+    (call printf.c "hello %d\0A" (suf -2147483648 "i32"))
+    (call printf.c "hello %lld\0A" (suf -9223372036854775808 "i64"))
+    (call printf.c "hello %lld\0A" (suf -9223372036854775806 "i64"))
+    (call printf.c "hello %llu\0A" (suf +18446744073709551615u "u64"))
+  ))
+
   (proc :main.c . (i +32) . (stmts
     1,1,hello.nim(var :x1.m . (i +32) +12)
     1,2,hello.nim(var :z2.m . (ptr (c +8)) (cast (ptr (c +8)) (suf "hello" "r")))
@@ -152,6 +159,7 @@
     (call foo.neg)
     (call foo.cs2)
     (call foo.floatspecial)
+    (call foo.intminmax)
 
     (var :x.c . (i +8) (suf +12 "i8"))
     (var :x.m . (i +16) (suf -12 "i16"))


### PR DESCRIPTION
`IL64` is generated in the codegen [here](https://github.com/nim-lang/nif/blob/a32cd8877c99c0cfdde87c3544b4d5ef676e7b5e/src/nifc/codegen.nim#L150-L155) but was not defined in the C prelude, now it is.

Also tests the generation and parsing of edge integer values like `-9223372036854775808`.