### PR TITLE
remove affixes in the filenames from the binary name

### DIFF
--- a/src/nifc/bat.nim
+++ b/src/nifc/bat.nim
@@ -1,5 +1,5 @@
 import std/[os, strformat, tables, syncio]
-import noptions
+import noptions, mangler
 
 proc generateMakefileForFiles(s: State, files: seq[string],
         action: Action, links: var string): string =
@@ -16,7 +16,7 @@ proc generateMakefileForFiles(s: State, files: seq[string],
   let nifcacheDir = s.config.nifcacheDir
   let destExt = ExtAction[action]
   for i in 0..<files.len:
-    let moduleNames = splitFile(files[i]).name
+    let moduleNames = splitFile(files[i]).name.mangleFileName
     links.add " " & nifcacheDir / moduleNames & ".o"
     result.add fmt"{cc} %c_flags% -c " &
           nifcacheDir / moduleNames & fmt"{destExt} -o " &

--- a/src/nifc/makefile.nim
+++ b/src/nifc/makefile.nim
@@ -1,5 +1,5 @@
 import std/[os, strformat, tables, syncio]
-import noptions
+import noptions, mangler
 
 proc generateMakefileForFiles(s: State, files: seq[string],
       action: Action,
@@ -19,7 +19,7 @@ proc generateMakefileForFiles(s: State, files: seq[string],
   let nifcacheDir = s.config.nifcacheDir
   let destExt = ExtAction[action]
   for i in 0..<files.len:
-    let moduleNames = splitFile(files[i]).name
+    let moduleNames = splitFile(files[i]).name.mangleFileName
     makefileContent.add " " & moduleNames & ".o"
     programBody.add " " & nifcacheDir / moduleNames & ".o"
     objectBody.add &"{moduleNames}.o:\n	{cc} $(CFLAGS) -c " &

--- a/src/nifc/mangler.nim
+++ b/src/nifc/mangler.nim
@@ -9,7 +9,7 @@
 
 ## Name mangling. See nifc-spec.md for details.
 
-from std / strutils import toOctal
+from std / strutils import toOctal, replace
 
 proc escape(result: var string; c: char) {.inline.} =
   const HexChars = "0123456789ABCDEF"
@@ -96,7 +96,12 @@ proc makeCString*(s: string): string =
   for c in s: toCChar(c, result)
   result.add('"')
 
+proc mangleFileName*(s: string): string =
+  result = s.replace(".", "dot")
+
 when isMainModule:
+  import std/assertions
+
   assert mangle"foo.3.baz" == "foo_3_baz"
   assert mangle"Query?" == "QQueryqmarkQ"
   assert mangle"abc_def_[]=" == "abcQ_defQ_putQ"

--- a/src/nifc/mangler.nim
+++ b/src/nifc/mangler.nim
@@ -9,7 +9,7 @@
 
 ## Name mangling. See nifc-spec.md for details.
 
-from std / strutils import toOctal, replace
+from std / strutils import toOctal, replace, endsWith
 
 proc escape(result: var string; c: char) {.inline.} =
   const HexChars = "0123456789ABCDEF"
@@ -96,8 +96,12 @@ proc makeCString*(s: string): string =
   for c in s: toCChar(c, result)
   result.add('"')
 
-proc mangleFileName*(s: string): string =
-  result = s.replace(".", "dot")
+template mangleFileName*(s: string): string =
+  # strip '.c' from filenames
+  if s.endsWith(".c"):
+    s[0..<s.len-2]
+  else:
+    s
 
 when isMainModule:
   import std/assertions

--- a/src/nifc/nifc.nim
+++ b/src/nifc/nifc.nim
@@ -106,7 +106,7 @@ proc handleCmdLine() =
         of atNative:
           actionTable[atNative].add key
         of atNone:
-          raiseAssert "unreachable"
+          quit "invalid command: " & key
     of cmdLongOption, cmdShortOption:
       case normalize(key)
       of "bits":

--- a/src/nifc/nifc.nim
+++ b/src/nifc/nifc.nim
@@ -10,7 +10,7 @@
 ## NIFC driver program.
 
 import std / [parseopt, strutils, os, osproc, tables, assertions, syncio]
-import codegen, noptions
+import codegen, noptions, mangler
 import preasm / genpreasm
 
 when defined(windows):
@@ -58,7 +58,7 @@ proc generateBackend(s: var State; action: Action; files: seq[string]; bits: int
   let destExt = if action == atC: ".c" else: ".cpp"
   for i in 0..<files.len:
     let inp = files[i]
-    let outp = s.config.nifcacheDir / splitFile(inp).name & destExt
+    let outp = s.config.nifcacheDir / splitFile(inp).name.mangleFileName & destExt
     generateCode s, inp, outp, bits
 
 proc handleCmdLine() =
@@ -173,7 +173,7 @@ proc handleCmdLine() =
       for x in s.selects:
         write h, "#include \"" & extractFilename(x) & "\"\n"
       h.close()
-    let appName = actionTable[currentAction][^1].splitFile.name
+    let appName = actionTable[currentAction][^1].splitFile.name.mangleFileName
 
     when defined(windows):
       let makefilePath = s.config.nifcacheDir / "Makefile." & appName & ".bat"

--- a/src/nifc/selectany.nim
+++ b/src/nifc/selectany.nim
@@ -72,7 +72,7 @@ proc inclHeader(c: var GeneratedCode) =
     c.includes.add Token NewLine
 
 proc genRoutineGuardBegin(c: var GeneratedCode; name: string) =
-  let guardName = name & "__" & mangle(c.m.filename.splitFile.name)
+  let guardName = name & "__" & mangle(c.m.filename.splitFile.name.mangleFileName)
 
   inclHeader(c)
 

--- a/tests/nifc/app.c.nif
+++ b/tests/nifc/app.c.nif
@@ -1,0 +1,9 @@
+(.nif24)
+(stmts
+  (proc :main.c . (i +32) . (stmts
+
+    (var :x.mangled . (f +32) 1.2)
+    (var :y.mangled . (f +64) 1.223)
+    (var :z.mangled . (f +64) 4.6)
+    (ret +0)
+  )))

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -223,6 +223,9 @@ proc testNifc(overwrite: bool) =
   let t2 = "tests/nifc/selectany/t2.nif"
   let t3 = "tests/nifc/selectany/t3.nif"
   exec ("src" / "nifc" / "nifc").addFileExt(ExeExt) & " c -r " & t1 & " " & t2 & " " & t3
+  let app = "tests/nifc/app.c.nif"
+  exec ("src" / "nifc" / "nifc").addFileExt(ExeExt) & " c -r " & app
+
   let hello = "tests/nifc/hello.nif"
   exec ("src" / "nifc" / "nifc").addFileExt(ExeExt) & " c -r " & hello
   exec ("src" / "nifc" / "nifc").addFileExt(ExeExt) & " c -r --opt:speed " & hello


### PR DESCRIPTION
e.g. without mangling, `test.c.nif` will generate a binary called `test.c` which is quite confusing