### PR TITLE
nifc: BranchValue supports (true) (false)

### DIFF
--- a/doc/nifc-spec.md
+++ b/doc/nifc-spec.md
@@ -118,7 +118,7 @@ Expr ::= Number | CharLiteral | StringLiteral |
          (conv Type Expr) |
          Call
 
-BranchValue ::= Number | CharLiteral | Symbol
+BranchValue ::= Number | CharLiteral | Symbol | (true) | (false)
 BranchRange ::= BranchValue | (range BranchValue BranchValue)
 BranchRanges ::= (ranges BranchRange+)
 

--- a/src/nifc/genstmts.nim
+++ b/src/nifc/genstmts.nim
@@ -68,13 +68,13 @@ proc genScope(c: var GeneratedCode; t: Tree; n: NodePos) =
   c.add CurlyRi
 
 proc genBranchValue(c: var GeneratedCode; t: Tree; n: NodePos) =
-  if t[n].kind in {IntLit, UIntLit, CharLit, Sym}:
+  if t[n].kind in {IntLit, UIntLit, CharLit, Sym, TrueC, FalseC}:
     c.genx t, n
   else:
     error c.m, "expected valid `of` value but got: ", t, n
 
 proc genCaseCond(c: var GeneratedCode; t: Tree; n: NodePos) =
-  # BranchValue ::= Number | CharLiteral | Symbol
+  # BranchValue ::= Number | CharLiteral | Symbol | (true) | (false)
   # BranchRange ::= BranchValue | (range BranchValue BranchValue)
   # BranchRanges ::= (ranges BranchRange+)
   if t[n].kind == RangesC:

--- a/src/nifc/nifc_grammar.nif
+++ b/src/nifc/nifc_grammar.nif
@@ -42,7 +42,7 @@
          Call
 ))
 
-(RULE :BranchValue (OR INTLIT UINTLIT CHARLITERAL SYMBOL))
+(RULE :BranchValue (OR INTLIT UINTLIT CHARLITERAL SYMBOL (false) (true)))
 (RULE :BranchRange (OR BranchValue (range BranchValue BranchValue)))
 (RULE :BranchRanges (OR (ranges (ONE_OR_MANY BranchRange))))
 

--- a/tests/data/nifc_grammar.nim
+++ b/tests/data/nifc_grammar.nim
@@ -516,6 +516,12 @@ proc matchBranchValue(c: var Context; it: var Item): bool =
     if lookupSym(c, it):
       or2 = true
       break or3
+    if isTag(c, it, FalseT):
+      or2 = true
+      break or3
+    if isTag(c, it, TrueT):
+      or2 = true
+      break or3
   if not or2: return false
   when declared(handleBranchValue):
     handleBranchValue(c, it, before1)

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -180,6 +180,14 @@
     (ret +1)
   ))
 
+  (proc :foo.switch.bool . . . (stmts
+    (var :x.c . (bool) (false))
+    (case x.c
+      (of (ranges (true)) (call printf.c "hello %d" x.c))
+      (of (ranges (false)) (call printf.c "hello %d" x.c))
+    )
+  ))
+
   (proc :main.c . (i +32) . (stmts
     1,1,hello.nim(var :x1.m . (i +32) +12)
     1,2,hello.nim(var :z2.m . (ptr (c +8)) (cast (ptr (c +8)) (suf "hello" "r")))
@@ -216,6 +224,8 @@
 
     (var :add2.m . (i +32) (add (i +32) +214 +21))
     (call printf.c "not: %d\0A" (bitnot (i +32) +12))
+
+    (call foo.switch.bool)
 
     (emit "(void)" x.c ";")
     (ret +0)


### PR DESCRIPTION
```
(case Expr (of BranchRanges StmtList)* (else StmtList)?)
```

The case expression is `Expr`. It's likely to be a bool. We need to support `(false)` `(true)` for `BranchValue`