### PR TITLE
nifc: add alignof & offsetof, make sizeof only take type

### DIFF
--- a/doc/nifc-spec.md
+++ b/doc/nifc-spec.md
@@ -97,6 +97,8 @@ Expr ::= Number | CharLiteral | StringLiteral |
          (not Expr) | # "!"
          (neg Type Expr) |
          (sizeof Expr) |
+         (alignof Type) |
+         (offsetof Type SYMBOL) |
          (oconstr Type (kv Symbol Expr)*) |  # (object constructor){...}
          (aconstr Type Expr*) |              # array constructor
          (add Type Expr Expr) |

--- a/doc/nifc-spec.md
+++ b/doc/nifc-spec.md
@@ -96,7 +96,7 @@ Expr ::= Number | CharLiteral | StringLiteral |
          (or Expr Expr) | # "||"
          (not Expr) | # "!"
          (neg Type Expr) |
-         (sizeof Expr) |
+         (sizeof Type) |
          (alignof Type) |
          (offsetof Type SYMBOL) |
          (oconstr Type (kv Symbol Expr)*) |  # (object constructor){...}

--- a/src/nifc/amd64/genasm_e.nim
+++ b/src/nifc/amd64/genasm_e.nim
@@ -785,7 +785,7 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos; dest: var Location) =
     genAddr c, t, n.firstSon, dest
   of SizeofC:
     # we evaluate it at compile-time:
-    let a = getAsmSlot(c, n.firstSon)
+    let a = typeToSlot(c, n.firstSon)
     let typ = AsmSlot(kind: AUInt, size: WordSize, align: WordSize)
     let d = immediateLoc(uint(a.size), typ)
     into c, dest, d

--- a/src/nifc/amd64/genasm_e.nim
+++ b/src/nifc/amd64/genasm_e.nim
@@ -789,6 +789,19 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos; dest: var Location) =
     let typ = AsmSlot(kind: AUInt, size: WordSize, align: WordSize)
     let d = immediateLoc(uint(a.size), typ)
     into c, dest, d
+  of AlignofC:
+    # we evaluate it at compile-time:
+    let a = typeToSlot(c, n.firstSon)
+    let typ = AsmSlot(kind: AUInt, size: WordSize, align: WordSize)
+    let d = immediateLoc(uint(a.align), typ)
+    into c, dest, d
+  of OffsetofC:
+    let (obj, fld) = sons2(t, n)
+    let field = t[fld].litId
+    let ftyp = c.fields[field]
+    let typ = AsmSlot(kind: AUInt, size: WordSize, align: WordSize)
+    let d = immediateLoc(uint(ftyp.offset), typ)
+    into c, dest, d
   of CallC: genCall c, t, n, dest
   of AddC: typedBinOp AddT
   of SubC: typedBinOp SubT

--- a/src/nifc/amd64/genasm_s.nim
+++ b/src/nifc/amd64/genasm_s.nim
@@ -319,10 +319,9 @@ proc genConstData(c: var GeneratedCode; t: Tree; n: NodePos) =
     let arg = n.firstSon
     genConstData c, t, arg
   of SizeofC:
-    let a = getAsmSlot(c, n.firstSon)
+    let a = typeToSlot(c, n.firstSon)
     c.genIntLit a.size, info
   of AlignofC:
-    # we evaluate it at compile-time:
     let a = typeToSlot(c, n.firstSon)
     c.genIntLit a.align, info
   of OffsetofC:

--- a/src/nifc/amd64/genasm_s.nim
+++ b/src/nifc/amd64/genasm_s.nim
@@ -321,6 +321,15 @@ proc genConstData(c: var GeneratedCode; t: Tree; n: NodePos) =
   of SizeofC:
     let a = getAsmSlot(c, n.firstSon)
     c.genIntLit a.size, info
+  of AlignofC:
+    # we evaluate it at compile-time:
+    let a = typeToSlot(c, n.firstSon)
+    c.genIntLit a.align, info
+  of OffsetofC:
+    let (obj, fld) = sons2(t, n)
+    let field = t[fld].litId
+    let ftyp = c.fields[field]
+    c.genIntLit ftyp.offset, info
   else:
     error c.m, "unsupported expression for const: ", t, n
 

--- a/src/nifc/amd64/register_allocator.nim
+++ b/src/nifc/amd64/register_allocator.nim
@@ -59,7 +59,7 @@ proc allocRegsForProc(c: var GeneratedCode; t: Tree; n: NodePos; weights: Table[
   let k = t[n].kind
   case k
   of Empty, Ident, SymDef, Sym, IntLit, UIntLit, FloatLit, CharLit, StrLit, Err,
-     NilC, FalseC, TrueC, SizeofC, InfC, NegInfC, NanC:
+     NilC, FalseC, TrueC, SizeofC, AlignofC, OffsetofC, InfC, NegInfC, NanC:
     discard
   of StmtsC, ScopeC:
     c.openScope()

--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -260,5 +260,15 @@ typedef NU8 NU;
 
 #define N_NOINLINE_PTR(rettype, name) rettype (*name)
 
+#if defined(_MSC_VER)
+#  define NIM_ALIGN(x)  __declspec(align(x))
+#  define NIM_ALIGNOF(x) __alignof(x)
+#else
+#  define NIM_ALIGN(x)  __attribute__((aligned(x)))
+#  define NIM_ALIGNOF(x) __alignof__(x)
+#endif
+
+#include <stddef.h>
+
 """
 

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -207,7 +207,7 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos) =
     let arg = n.firstSon
     c.add "sizeof"
     c.add ParLe
-    genx c, t, arg
+    genType c, t, arg
     c.add ParRi
   of AlignofC:
     let arg = n.firstSon

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -209,6 +209,22 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos) =
     c.add ParLe
     genx c, t, arg
     c.add ParRi
+  of AlignofC:
+    let arg = n.firstSon
+    c.add "NIM_ALIGNOF"
+    c.add ParLe
+    genType c, t, arg
+    c.add ParRi
+  of OffsetofC:
+    let (typ, mem) = sons2(t, n)
+    c.add "offsetof"
+    c.add ParLe
+    genType c, t, typ
+    c.add Comma
+    let lit = t[mem].litId
+    let name = mangle(c.m.lits.strings[lit])
+    c.add name
+    c.add ParRi
   of CallC: genCall c, t, n
   of AddC: typedBinOp " + "
   of SubC: typedBinOp " - "

--- a/src/nifc/native/analyser.nim
+++ b/src/nifc/native/analyser.nim
@@ -63,7 +63,7 @@ proc analyseVarUsages(c: var Context; t: Tree; n: NodePos) =
   let k = t[n].kind
   case k
   of Empty, Ident, SymDef, IntLit, UIntLit, FloatLit, CharLit, StrLit, Err,
-     NilC, FalseC, TrueC, SizeofC, InfC, NegInfC, NanC:
+     NilC, FalseC, TrueC, SizeofC, AlignofC, OffsetofC, InfC, NegInfC, NanC:
     discard
   of StmtsC, ScopeC:
     c.openScope()

--- a/src/nifc/nifc_grammar.nif
+++ b/src/nifc/nifc_grammar.nif
@@ -19,7 +19,7 @@
          (or Expr Expr)
          (not Expr)
          (neg Type Expr)
-         (sizeof Expr)
+         (sizeof Type)
          (alignof Type)
          (offsetof Type SYMBOL)
          (oconstr Type (ZERO_OR_MANY (kv SYMBOL Expr)))

--- a/src/nifc/nifc_grammar.nif
+++ b/src/nifc/nifc_grammar.nif
@@ -20,6 +20,8 @@
          (not Expr)
          (neg Type Expr)
          (sizeof Expr)
+         (alignof Type)
+         (offsetof Type SYMBOL)
          (oconstr Type (ZERO_OR_MANY (kv SYMBOL Expr)))
          (aconstr Type (ZERO_OR_MANY Expr))
          (add Type Expr Expr)

--- a/src/nifc/nifc_model.nim
+++ b/src/nifc/nifc_model.nim
@@ -29,6 +29,8 @@ type
     NotC = "not"
     NegC = "neg"
     SizeofC = "sizeof"
+    AlignofC = "alignof"
+    OffsetofC = "offsetof"
     OconstrC = "oconstr"
     AconstrC = "aconstr"
     KvC = "kv"

--- a/src/nifc/preasm/genpreasm_e.nim
+++ b/src/nifc/preasm/genpreasm_e.nim
@@ -267,7 +267,7 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos; mode: XMode) =
     genx c, t, n.firstSon, WantAddr
   of SizeofC:
     # we evaluate it at compile-time:
-    let a = getAsmSlot(c, n.firstSon)
+    let a = typeToSlot(c, n.firstSon)
     genIntLit c, a.size, info
   of AlignofC:
     # we evaluate it at compile-time:

--- a/src/nifc/preasm/genpreasm_e.nim
+++ b/src/nifc/preasm/genpreasm_e.nim
@@ -269,6 +269,15 @@ proc genx(c: var GeneratedCode; t: Tree; n: NodePos; mode: XMode) =
     # we evaluate it at compile-time:
     let a = getAsmSlot(c, n.firstSon)
     genIntLit c, a.size, info
+  of AlignofC:
+    # we evaluate it at compile-time:
+    let a = typeToSlot(c, n.firstSon)
+    genIntLit c, a.align, info
+  of OffsetofC:
+    let (obj, fld) = sons2(t, n)
+    let field = t[fld].litId
+    let ftyp = c.fields[field]
+    genIntLit c, ftyp.offset, info
   of CallC: genCall c, t, n
   of AddC: typedBinOp AddT
   of SubC: typedBinOp SubT

--- a/src/nifc/typenav.nim
+++ b/src/nifc/typenav.nim
@@ -96,7 +96,7 @@ proc getType*(m: var Module; t: Tree; n: NodePos): TypeDesc =
   of FldC:
     let v = asFieldDecl(t, n)
     result = TypeDesc(p: v.typ)
-  of IntLit, SizeofC: result = createIntegralType(m.lits, IntC, "-1")
+  of IntLit, SizeofC, AlignofC, OffsetofC: result = createIntegralType(m.lits, IntC, "-1")
   of UIntLit: result = createIntegralType(m.lits, UIntC, "-1")
   of FloatLit, InfC, NegInfC, NanC: result = createIntegralType(m.lits, FloatC, "64")
   of CharLit: result = createIntegralType(m.lits, CharC, "8")

--- a/tests/data/nifc_grammar.nim
+++ b/tests/data/nifc_grammar.nim
@@ -207,8 +207,8 @@ proc matchExpr(c: var Context; it: var Item): bool =
       break or3
     var kw10 = false
     if isTag(c, it, SizeofT):
-      if not matchExpr(c, it):
-        error(c, it, "Expr expected")
+      if not matchType(c, it):
+        error(c, it, "Type expected")
         break or3
       kw10 = matchParRi(c, it)
     if kw10:

--- a/tests/data/nifc_grammar.nim
+++ b/tests/data/nifc_grammar.nim
@@ -215,13 +215,34 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw11 = false
+    if isTag(c, it, AlignofT):
+      if not matchType(c, it):
+        error(c, it, "Type expected")
+        break or3
+      kw11 = matchParRi(c, it)
+    if kw11:
+      or2 = true
+      break or3
+    var kw12 = false
+    if isTag(c, it, OffsetofT):
+      if not matchType(c, it):
+        error(c, it, "Type expected")
+        break or3
+      if not lookupSym(c, it):
+        error(c, it, "SYMBOL expected")
+        break or3
+      kw12 = matchParRi(c, it)
+    if kw12:
+      or2 = true
+      break or3
+    var kw13 = false
     if isTag(c, it, OconstrT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
-      var zm12 = true
+      var zm14 = true
       while not peekParRi(c, it):
-        var kw13 = false
+        var kw15 = false
         if isTag(c, it, KvT):
           if not lookupSym(c, it):
             error(c, it, "SYMBOL expected")
@@ -229,66 +250,36 @@ proc matchExpr(c: var Context; it: var Item): bool =
           if not matchExpr(c, it):
             error(c, it, "Expr expected")
             break or3
-          kw13 = matchParRi(c, it)
-        if not kw13:
-          zm12 = false
+          kw15 = matchParRi(c, it)
+        if not kw15:
+          zm14 = false
           break
-      if not zm12:
+      if not zm14:
         error(c, it, "invalid Expr")
         break or3
-      kw11 = matchParRi(c, it)
-    if kw11:
+      kw13 = matchParRi(c, it)
+    if kw13:
       or2 = true
       break or3
-    var kw14 = false
+    var kw16 = false
     if isTag(c, it, AconstrT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
-      var zm15 = true
+      var zm17 = true
       while not peekParRi(c, it):
         if not matchExpr(c, it):
-          zm15 = false
+          zm17 = false
           break
-      if not zm15:
+      if not zm17:
         error(c, it, "invalid Expr")
-        break or3
-      kw14 = matchParRi(c, it)
-    if kw14:
-      or2 = true
-      break or3
-    var kw16 = false
-    if isTag(c, it, AddT):
-      if not matchType(c, it):
-        error(c, it, "Type expected")
-        break or3
-      if not matchExpr(c, it):
-        error(c, it, "Expr expected")
-        break or3
-      if not matchExpr(c, it):
-        error(c, it, "Expr expected")
         break or3
       kw16 = matchParRi(c, it)
     if kw16:
       or2 = true
       break or3
-    var kw17 = false
-    if isTag(c, it, SubT):
-      if not matchType(c, it):
-        error(c, it, "Type expected")
-        break or3
-      if not matchExpr(c, it):
-        error(c, it, "Expr expected")
-        break or3
-      if not matchExpr(c, it):
-        error(c, it, "Expr expected")
-        break or3
-      kw17 = matchParRi(c, it)
-    if kw17:
-      or2 = true
-      break or3
     var kw18 = false
-    if isTag(c, it, MulT):
+    if isTag(c, it, AddT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -303,7 +294,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw19 = false
-    if isTag(c, it, DivT):
+    if isTag(c, it, SubT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -318,7 +309,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw20 = false
-    if isTag(c, it, ModT):
+    if isTag(c, it, MulT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -333,7 +324,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw21 = false
-    if isTag(c, it, ShrT):
+    if isTag(c, it, DivT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -348,7 +339,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw22 = false
-    if isTag(c, it, ShlT):
+    if isTag(c, it, ModT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -363,7 +354,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw23 = false
-    if isTag(c, it, BitandT):
+    if isTag(c, it, ShrT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -378,7 +369,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw24 = false
-    if isTag(c, it, BitorT):
+    if isTag(c, it, ShlT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -393,9 +384,12 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw25 = false
-    if isTag(c, it, BitnotT):
+    if isTag(c, it, BitandT):
       if not matchType(c, it):
         error(c, it, "Type expected")
+        break or3
+      if not matchExpr(c, it):
+        error(c, it, "Expr expected")
         break or3
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
@@ -405,7 +399,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw26 = false
-    if isTag(c, it, BitxorT):
+    if isTag(c, it, BitorT):
       if not matchType(c, it):
         error(c, it, "Type expected")
         break or3
@@ -420,9 +414,9 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw27 = false
-    if isTag(c, it, EqT):
-      if not matchExpr(c, it):
-        error(c, it, "Expr expected")
+    if isTag(c, it, BitnotT):
+      if not matchType(c, it):
+        error(c, it, "Type expected")
         break or3
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
@@ -432,7 +426,10 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw28 = false
-    if isTag(c, it, NeqT):
+    if isTag(c, it, BitxorT):
+      if not matchType(c, it):
+        error(c, it, "Type expected")
+        break or3
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
         break or3
@@ -444,7 +441,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw29 = false
-    if isTag(c, it, LeT):
+    if isTag(c, it, EqT):
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
         break or3
@@ -456,7 +453,7 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw30 = false
-    if isTag(c, it, LtT):
+    if isTag(c, it, NeqT):
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
         break or3
@@ -468,9 +465,9 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw31 = false
-    if isTag(c, it, CastT):
-      if not matchType(c, it):
-        error(c, it, "Type expected")
+    if isTag(c, it, LeT):
+      if not matchExpr(c, it):
+        error(c, it, "Expr expected")
         break or3
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
@@ -480,6 +477,30 @@ proc matchExpr(c: var Context; it: var Item): bool =
       or2 = true
       break or3
     var kw32 = false
+    if isTag(c, it, LtT):
+      if not matchExpr(c, it):
+        error(c, it, "Expr expected")
+        break or3
+      if not matchExpr(c, it):
+        error(c, it, "Expr expected")
+        break or3
+      kw32 = matchParRi(c, it)
+    if kw32:
+      or2 = true
+      break or3
+    var kw33 = false
+    if isTag(c, it, CastT):
+      if not matchType(c, it):
+        error(c, it, "Type expected")
+        break or3
+      if not matchExpr(c, it):
+        error(c, it, "Expr expected")
+        break or3
+      kw33 = matchParRi(c, it)
+    if kw33:
+      or2 = true
+      break or3
+    var kw34 = false
     if isTag(c, it, ConvT):
       if not matchType(c, it):
         error(c, it, "Type expected")
@@ -487,8 +508,8 @@ proc matchExpr(c: var Context; it: var Item): bool =
       if not matchExpr(c, it):
         error(c, it, "Expr expected")
         break or3
-      kw32 = matchParRi(c, it)
-    if kw32:
+      kw34 = matchParRi(c, it)
+    if kw34:
       or2 = true
       break or3
     if matchCall(c, it):

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -134,6 +134,13 @@
   )
   )
 
+  (proc :foo.alignoffset . . . (stmts
+    (call printf.c "align %lu\0A" (alignof (i +32)))
+    (call printf.c "align obj %lu\0A" (alignof MyObject2.m))
+    (call printf.c "offset obj 1 %lu\0A" (offsetof MyObject2.m a2))
+    (call printf.c "offset obj 2 %lu\0A" (offsetof MyObject2.m a3))
+  ))
+
   (proc :foo.floatspecial . . . (stmts
     (var :x.m . (f +32) (inf))
     (var :x2.m . (f +64) (neginf))
@@ -199,6 +206,7 @@
     (call foo.while)
     (call foo.neg)
     (call foo.cs2)
+    (call foo.alignoffset)
     (call foo.floatspecial)
     (call foo.intminmax)
 

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -107,13 +107,13 @@
     (call printf.c "hello %s" "file 3")
 
     (var :x.c . (bool) (true))
-    (call printf.c "hello %lu" (sizeof x.c))
+    (call printf.c "hello %lu" (sizeof (bool)))
 
     (var :y.c . MyObject2.mc (oconstr MyObject2.mc (kv a2.c +12) (kv a3.c (true))))
 
     (call printf.c "hello %ld\0A" (dot y.c a2.c +0))
 
-    (call printf.c "hello %lu\0A" (sizeof x.c))
+    (call printf.c "hello %lu\0A" (sizeof (bool)))
 
     (call printf.c "hello %d\0A" (and (par +1) (par +0)))
     (call printf.c "hello %d\0A" (or (par +1) (par -0)))
@@ -134,7 +134,9 @@
   )
   )
 
-  (proc :foo.alignoffset . . . (stmts
+  (proc :foo.sizealignoffset . . . (stmts
+    (call printf.c "size %lu\0A" (sizeof (i +32)))
+    (call printf.c "size obj %lu\0A" (sizeof MyObject2.m))
     (call printf.c "align %lu\0A" (alignof (i +32)))
     (call printf.c "align obj %lu\0A" (alignof MyObject2.m))
     (call printf.c "offset obj 1 %lu\0A" (offsetof MyObject2.m a2))
@@ -206,7 +208,7 @@
     (call foo.while)
     (call foo.neg)
     (call foo.cs2)
-    (call foo.alignoffset)
+    (call foo.sizealignoffset)
     (call foo.floatspecial)
     (call foo.intminmax)
 


### PR DESCRIPTION
Unlike `sizeof`, `alignof` and `offsetof` only expect a type in C, so `sizeof` also now accepts only types instead of only expressions.