### PR TITLE
fixes nifler generates incorrect visibility field

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -229,7 +229,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
     toNif(name, n, c)
 
     if visibility != nil:
-      c.b.addRaw "x"
+      c.b.addRaw " x"
     else:
       c.b.addEmpty
 
@@ -303,7 +303,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
       toNif(name, n[i], c) # name
 
       if visibility != nil:
-        c.b.addRaw "x"
+        c.b.addRaw " x"
       else:
         c.b.addEmpty
 
@@ -451,7 +451,7 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
 
     toNif(name, n, c)
     if visibility != nil:
-      c.b.addRaw "x"
+      c.b.addRaw " x"
     else:
       c.b.addEmpty
 


### PR DESCRIPTION
from `(let mx . . 4 +123)` to `(let m x . . 4 +123)`