### PR TITLE
implements `(err)` as a threadlocal variable

### DIFF
--- a/src/nifc/cprelude.nim
+++ b/src/nifc/cprelude.nim
@@ -270,5 +270,34 @@ typedef NU8 NU;
 
 #include <stddef.h>
 
+
+/*
+  NIM_THREADVAR declaration based on
+  https://stackoverflow.com/questions/18298280/how-to-declare-a-variable-as-thread-local-portably
+*/
+#if defined _WIN32
+#  if defined _MSC_VER || defined __BORLANDC__
+#    define NIM_THREADVAR __declspec(thread)
+#  else
+#    define NIM_THREADVAR __thread
+#  endif
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#  define NIM_THREADVAR _Thread_local
+#elif defined _WIN32 && ( \
+       defined _MSC_VER || \
+       defined __ICL || \
+       defined __BORLANDC__ )
+#  define NIM_THREADVAR __declspec(thread)
+#elif defined(__TINYC__) || defined(__GENODE__)
+#  define NIM_THREADVAR
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+#elif defined __GNUC__ || \
+       defined __SUNPRO_C || \
+       defined __xlC__
+#  define NIM_THREADVAR __thread
+#else
+#  error "Cannot define NIM_THREADVAR"
+#endif
+
 """
 

--- a/src/nifc/genexprs.nim
+++ b/src/nifc/genexprs.nim
@@ -106,6 +106,14 @@ proc genLvalue(c: var GeneratedCode; t: Tree; n: NodePos) =
     c.add Dot
     genx c, t, fld
   of ErrC:
+    if {gfMainModule, gfHasError} * c.flags == {}:
+      moveToDataSection:
+        c.add ExternKeyword
+        c.add ThreadVarToken
+        c.add "NB8 "
+        c.add ErrToken
+        c.add Semicolon
+      c.flags.incl gfHasError
     c.add ErrToken
   else:
     error c.m, "expected expression but got: ", t, n

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -197,9 +197,8 @@
     )
   ))
 
-  (var :err.c . (bool) (false))
-
-  (proc :foo.error.stmts (params (param :err.c . (bool))) . (pragmas (errs)) (stmts
+  (proc :foo.error.stmts . . (pragmas (errs)) (stmts
+    (asgn (err) (true))
     (call assert.c (err))
     (asgn (err) (false))
   )
@@ -258,7 +257,7 @@
     (emit "(void)" x.c ";")
 
 
-    (onerr (jmp L1.c) foo.error.stmts (true))
+    (onerr (jmp L1.c) foo.error.stmts)
     (call printf.c "success!\0A")
     (lab :L1.c)
 

--- a/tests/nifc/try.nif
+++ b/tests/nifc/try.nif
@@ -3,7 +3,7 @@
   (incl "<assert.h>")
   (incl "<stdio.h>")
 
-  (proc :foo.c (params (param :err.c . (bool))) . .
+  (proc :foo.c . . .
     (asgn (err) (true))
     (call assert.c (err))
   )
@@ -13,7 +13,7 @@
     (stmts
 
     (call assert.c (eq +2 +2))
-    (call foo.c (false))
+    (call foo.c)
 
       (try
         (stmts


### PR DESCRIPTION
It generates `NIM_THREADVAR NB8 NIFC_ERR_;` for the main module.
When it is used in the other module, `extern NIM_THREADVAR NB8 NIFC_ERR_;` will be produced.