### PR TITLE
nimony: don't call sigmatch on undeclared identifier

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1054,6 +1054,10 @@ proc semCall(c: var SemContext; it: var Item) =
       else:
         buildErr c, fn.n.info, "`choice` node does not contain `symbol`"
       inc f
+  elif fn.n.kind == Ident:
+    # error should have been given above already:
+    # buildErr c, fn.n.info, "attempt to call undeclared routine"
+    discard
   else:
     m.add createMatch()
     sigmatch(m[^1], fn, args, emptyNode())


### PR DESCRIPTION
Calling sigmatch causes an assert failure rather than propagating the `undeclared identifier` error.