### PR TITLE
nimony: support discardable

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -265,7 +265,7 @@ proc parsePragmas(e: var EContext; c: var Cursor): CollectedPragmas =
           expectStrLit e, c
           result.externName = pool.strings[c.litId]
           inc c
-        of Nodecl, Selectany, Threadvar, Globalvar:
+        of Nodecl, Selectany, Threadvar, Globalvar, Discardable, NoReturn:
           result.flags.incl pk
           inc c
         of Header:

--- a/src/lib/nifcursors.nim
+++ b/src/lib/nifcursors.nim
@@ -100,7 +100,7 @@ proc beginRead*(b: var TokenBuf): Cursor =
   inc b.readers
   result = Cursor(p: addr(b.data[0]), rem: b.len)
 
-proc endRead*(b: var TokenBuf; c: Cursor) =
+proc endRead*(b: var TokenBuf) =
   assert b.readers > 0, "unpaired endRead"
   dec b.readers
   if b.readers == 0: thaw(b)

--- a/src/nimony/nimony_model.nim
+++ b/src/nimony/nimony_model.nim
@@ -176,6 +176,8 @@ type
     Selectany = "selectany"
     Threadvar = "threadvar"
     Globalvar = "global"
+    Discardable = "discardable"
+    NoReturn = "noreturn"
 
   SubstructureKind* = enum
     NoSub

--- a/src/nimony/tests/tbasic.nim
+++ b/src/nimony/tests/tbasic.nim
@@ -31,3 +31,9 @@ discard foo(global.x, "123")
 
 overloaded()
 overloaded("abc")
+
+proc discardable(x: int): int {.discardable.} =
+  result = x + 7
+
+discardable(123)
+discard discardable(123)


### PR DESCRIPTION
Mirrors [Nim's implementation](https://github.com/nim-lang/Nim/blob/e7f48cdd5c17cbd0c1c74c2c1f360ae2ea122b64/compiler/semstmts.nim#L140).

`endRead` and `skipParRi` had some extra parameters that were not needed. Single word pragmas also had a bug where they added a `ParLe` token but not a `ParRi` one.