### PR TITLE
nimony: fix discardable after combineType changes

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1098,9 +1098,7 @@ proc semStmt(c: var SemContext; n: var Cursor) =
     let ex = cursorAt(c.dest, exPos)
     let discardable = implicitlyDiscardable(ex)
     endRead(c.dest)
-    if discardable:
-      it.typ = c.types.voidType
-    else:
+    if not discardable:
       buildErr c, info, "expression of type `" & typeToString(it.typ) & "` must be discarded"
   n = it.n
 

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1099,7 +1099,7 @@ proc semStmt(c: var SemContext; n: var Cursor) =
     let discardable = implicitlyDiscardable(ex)
     endRead(c.dest)
     if discardable:
-      combineType c, info, it.typ, c.types.voidType
+      it.typ = c.types.voidType
     else:
       buildErr c, info, "expression of type `" & typeToString(it.typ) & "` must be discarded"
   n = it.n


### PR DESCRIPTION
refs #136, refs #133

Since #133 `tests/basics/t1` gives:

```
src/nimony/tests/basics/t1.nim(38, 12) Error: type mismatch: got: . but wanted: (i -1)
```

but the tester does not seem to catch this, maybe it doesn't produce a failure exit code?

The issue itself is fixed by just not modifying `it.typ` at all since it's not used after.