### PR TITLE
nifc: ignore undeclared .c types in type dependencies

### DIFF
--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -62,7 +62,11 @@ proc recordDependency(m: Module; o: var TypeOrder; parent, child: TypeId) =
     let id = m.code[ch].litId
     let def = m.defs.getOrDefault(id)
     if def.pos == NodePos(0):
-      error m, "undeclared symbol: ", m.code, ch
+      if m.lits.strings[id].endsWith(".c"):
+        # imported from c, no need to check dependency
+        discard
+      else:
+        error m, "undeclared symbol: ", m.code, ch
     else:
       let decl = asTypeDecl(m.code, def.pos)
       if not containsOrIncl(o.lookedAtBodies, decl.body.int):

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -212,9 +212,18 @@
   )
   )
 
+  (type :ContainsImported.m . (object .
+    (fld :x.f . unsigned\20char.c)))
+
+  (proc :foo.escapedproc (params (param :x.p . unsigned\20char.c)) unsigned\20char.c . (stmts
+    (ret x.p)
+  ))
+
   (proc :foo.escaped . . . (stmts
     (var :x.m . unsigned\20char.c +12)
     (call assert.c (eq x.m +12))
+    (call assert.c (eq (call foo.escapedproc x.m) x.m))
+    (var :y.m . ContainsImported.m .)
   ))
 
   (proc :main.c . (i +32) (pragmas (errs)) (stmts


### PR DESCRIPTION
Before, types with fields with `.c` types would give undeclared identifier errors in this code, but it's not necessary to track these since they're imported from C.