### PR TITLE
mark `error` functions `{.noreturn.}`

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -52,7 +52,7 @@ proc load(e: var EContext; suffix: string): NifModule =
   else:
     result = e.mods[suffix]
 
-proc error(e: var EContext; msg: string; c: Cursor) =
+proc error(e: var EContext; msg: string; c: Cursor) {.noreturn.} =
   write stdout, "[Error] "
   write stdout, msg
   writeLine stdout, toString(c)
@@ -60,7 +60,7 @@ proc error(e: var EContext; msg: string; c: Cursor) =
     echo getStackTrace()
   quit 1
 
-proc error(e: var EContext; msg: string) =
+proc error(e: var EContext; msg: string) {.noreturn.} =
   write stdout, "[Error] "
   write stdout, msg
   when defined(debug):

--- a/src/nifc/amd64/emitter.nim
+++ b/src/nifc/amd64/emitter.nim
@@ -82,7 +82,7 @@ proc isTag(c: var Context; tag: TagId): bool =
   else:
     result = false
 
-proc error(c: var Context; msg: string) =
+proc error(c: var Context; msg: string) {.noreturn.} =
   if c.current.info.isValid:
     let (f, line, col) = unpack(pool.man, c.current.info)
     echo "[Error] ", pool.files[f] & "(" & $line & ", " & $col & "): " & msg

--- a/src/nifc/amd64/genasm.nim
+++ b/src/nifc/amd64/genasm.nim
@@ -50,7 +50,7 @@ type
 proc initGeneratedCode*(m: sink Module; intmSize: int): GeneratedCode =
   result = GeneratedCode(m: m, intmSize: intmSize)
 
-proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) =
+proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) {.noreturn.} =
   write stdout, "[Error] "
   write stdout, msg
   writeLine stdout, toString(tree, n, m)

--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -144,7 +144,7 @@ proc writeTokenSeq(f: var CppFile; s: seq[Token]; c: GeneratedCode) =
     else:
       write f, c.tokens[x]
 
-proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) =
+proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) {.noreturn.} =
   write stdout, "[Error] "
   write stdout, msg
   writeLine stdout, toString(tree, n, m)

--- a/src/nifc/preasm/genpreasm.nim
+++ b/src/nifc/preasm/genpreasm.nim
@@ -53,7 +53,7 @@ proc closeScope(c: var GeneratedCode) =
 proc initGeneratedCode*(m: sink Module; intmSize: int): GeneratedCode =
   result = GeneratedCode(m: m, intmSize: intmSize)
 
-proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) =
+proc error(m: Module; msg: string; tree: PackedTree[NifcKind]; n: NodePos) {.noreturn.} =
   when defined(debug):
     writeStackTrace()
   write stdout, "[Error] "

--- a/src/nifgram/nifgram.nim
+++ b/src/nifgram/nifgram.nim
@@ -30,7 +30,7 @@ type
     declaredVar, collectInto, flipVar: string
     specTags, foundTags: OrderedTable[string, int] # maps to the arity for more checking
 
-proc error(c: var Context; msg: string) =
+proc error(c: var Context; msg: string) {.noreturn.} =
   #writeStackTrace()
   quit "[Error] in RULE " & c.currentRule & "(" & $c.r.line & "): " & msg
 

--- a/src/nimony/programs.nim
+++ b/src/nimony/programs.nim
@@ -57,7 +57,7 @@ proc loadInterface*(suffix: string; importTab: var Iface) =
     let symId = pool.syms.getOrIncl(k)
     importTab.mgetOrPut(strId, @[]).add symId
 
-proc error*(msg: string; c: Cursor) =
+proc error*(msg: string; c: Cursor) {.noreturn.} =
   write stdout, "[Error] "
   write stdout, msg
   writeLine stdout, toString(c, false)
@@ -65,7 +65,7 @@ proc error*(msg: string; c: Cursor) =
     echo getStackTrace()
   quit 1
 
-proc error*(msg: string) =
+proc error*(msg: string) {.noreturn.} =
   write stdout, "[Error] "
   write stdout, msg
   when defined(debug):


### PR DESCRIPTION
so that it works better with `strictdefs`