### PR TITLE
nimony: fixes enum types

### DIFF
--- a/src/nifler/bridge.nim
+++ b/src/nifler/bridge.nim
@@ -423,7 +423,6 @@ proc toNif*(n, parent: PNode; c: var TranslationContext) =
       relLineInfo(it, n, c)
 
       c.b.addTree("efld")
-      relLineInfo(it, n, c)
 
       toNif name, it, c
       c.b.addEmpty # export marker

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1594,7 +1594,6 @@ proc semObjectType(c: var SemContext; n: var Cursor) =
 
 proc semEnumType(c: var SemContext; n: var Cursor) =
   takeToken c, n
-  wantDot c, n
   while n.substructureKind == EfldS:
     semLocal(c, n, EfldY)
   wantParRi c, n

--- a/src/nimony/tests/basics/t1.nim
+++ b/src/nimony/tests/basics/t1.nim
@@ -6,6 +6,11 @@ type
   float* {.magic: Float.}
   string* {.magic: String.}
 
+  Color* = enum
+    red = 0, blue = 1
+
+  bool* {.magic: Bool.} = enum ## Built-in boolean type.
+    false = 0, true = 1
 
 proc `+`*(x, y: int): int {.magic: "AddI".}
 


### PR DESCRIPTION
`relLineInfo(it, n, c)` should be added before a node, not after a node. It causes conflicts with the lineinfos of the internal nodes otherwise and produces an UnknownToken with consecutive lineinfos.
e.g.
 
```
(enum 14,1
   (efld 14,1 ~8 false . . . +0)
```