### PR TITLE
nifc: fix toString for numbers, fixes align pragma

### DIFF
--- a/src/nifc/nifc_model.nim
+++ b/src/nifc/nifc_model.nim
@@ -320,8 +320,10 @@ proc toString(b: var Builder; tree: PackedTree[NifcKind]; n: NodePos; m: Module)
     b.addEmpty()
   of Ident:
     b.addIdent(m.lits.strings[tree[n].litId])
-  of Sym, IntLit, UIntLit, FloatLit:
+  of Sym:
     b.addSymbol(m.lits.strings[tree[n].litId])
+  of IntLit, UIntLit, FloatLit:
+    b.addNumber(m.lits.strings[tree[n].litId])
   of SymDef:
     b.addSymbolDef(m.lits.strings[tree[n].litId])
   of CharLit:

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -134,6 +134,9 @@
   )
   )
 
+  (type :MyObject.aligned . (object .
+    (fld :a1 (pragmas (align 8)) (bool))))
+
   (proc :foo.sizealignoffset . . . (stmts
     (call assert.c (eq (sizeof (i +32)) +4))
     (call assert.c (eq (sizeof MyObject2.m) +24))
@@ -141,6 +144,7 @@
     (call assert.c (eq (alignof MyObject2.m) +8))
     (call assert.c (eq (offsetof MyObject2.m a2) +8))
     (call assert.c (eq (offsetof MyObject2.m a3) +16))
+    (call assert.c (eq (sizeof MyObject.aligned) +8))
   ))
 
   (proc :foo.floatspecial . . . (stmts

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -135,7 +135,7 @@
   )
 
   (type :MyObject.aligned . (object .
-    (fld :a1 (pragmas (align 8)) (bool))))
+    (fld :a1.c (pragmas (align +8)) (bool))))
 
   (proc :foo.sizealignoffset . . . (stmts
     (call assert.c (eq (sizeof (i +32)) +4))


### PR DESCRIPTION
Calling `addSymbol` escapes the output, giving something like `NIM_ALIGN(\2B16)`.