### PR TITLE
nifc: use _PTR macros for proc type call conventions

### DIFF
--- a/src/nifc/codegen.nim
+++ b/src/nifc/codegen.nim
@@ -179,6 +179,19 @@ proc genUIntLit(c: var GeneratedCode; litId: StrId) =
 
 # Type graph
 
+const
+  CallingConvToStr: array[CdeclC..NoinlineC, string] = [
+    "N_CDECL",
+    "N_STDCALL", "N_SAFECALL",
+    "N_SYSCALL", # this is probably not correct for all platforms,
+                 # but one can #define it to what one wants
+    "N_FASTCALL",
+    "N_THISCALL",
+    "N_NOCONV",
+    "N_NOCONV", #ccMember is N_NOCONV
+    "N_INLINE", "N_NOINLINE"
+    ]
+
 include gentypes
 
 # Procs
@@ -333,20 +346,6 @@ proc genVarDecl(c: var GeneratedCode; t: Tree; n: NodePos; vk: VarKind; toExtern
     error c.m, "expected SymbolDef but got: ", t, n
 
 include genstmts
-
-
-const
-  CallingConvToStr: array[CdeclC..NoinlineC, string] = [
-    "N_CDECL",
-    "N_STDCALL", "N_SAFECALL",
-    "N_SYSCALL", # this is probably not correct for all platforms,
-                 # but one can #define it to what one wants
-    "N_FASTCALL",
-    "N_THISCALL",
-    "N_NOCONV",
-    "N_NOCONV", #ccMember is N_NOCONV
-    "N_INLINE", "N_NOINLINE"
-    ]
 
 
 proc genProcDecl(c: var GeneratedCode; t: Tree; n: NodePos; isExtern: bool) =

--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -127,7 +127,8 @@ proc genProcTypePragma(c: var GeneratedCode; types: TypeGraph; n: NodePos; isVar
   # ProcTypePragma ::= CallingConvention | (varargs) | Attribute
   case types[n].kind
   of CallingConventions:
-    c.add " __" & $types[n].kind
+    if types[n].kind != NodeclC:
+      c.add " __" & $types[n].kind
   of VarargsC:
     isVarargs = true
   of AttrC:

--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -126,9 +126,9 @@ template integralBits(types: TypeGraph; t: TypeId): string =
 proc genProcTypePragma(c: var GeneratedCode; types: TypeGraph; n: NodePos; isVarargs: var bool) =
   # ProcTypePragma ::= CallingConvention | (varargs) | Attribute
   case types[n].kind
-  of CallingConventions:
-    if types[n].kind != NodeclC:
-      c.add " __" & $types[n].kind
+  of CallingConventions - {NoconvC, MemberC}:
+    c.add " __" & $types[n].kind
+  of NoconvC, MemberC: discard
   of VarargsC:
     isVarargs = true
   of AttrC:

--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -126,9 +126,8 @@ template integralBits(types: TypeGraph; t: TypeId): string =
 proc genProcTypePragma(c: var GeneratedCode; types: TypeGraph; n: NodePos; isVarargs: var bool) =
   # ProcTypePragma ::= CallingConvention | (varargs) | Attribute
   case types[n].kind
-  of CallingConventions - {NoconvC, MemberC}:
-    c.add " __" & $types[n].kind
-  of NoconvC, MemberC: discard
+  of CallingConventions:
+    discard "already handled"
   of VarargsC:
     isVarargs = true
   of AttrC:
@@ -255,17 +254,38 @@ proc genType(c: var GeneratedCode; types: TypeGraph; t: TypeId; name = "") =
     c.add BracketRi
   of ProctypeC:
     let decl = asProcType(types, t)
-    if types[decl.returnType].kind == Empty:
-      c.add "void"
-    else:
-      genType c, types, decl.returnType
-    c.add Space
-    c.add ParLe
+    var lastCallConv = Empty
+    if types[decl.pragmas].kind == PragmasC:
+      for ch in sons(types, decl.pragmas):
+        case types[ch].kind
+        of CallingConventions:
+          lastCallConv = types[ch].kind
+        else:
+          discard
     var isVarargs = false
-    genProcTypePragmas c, types, decl.pragmas, isVarargs
-    c.add Star # "(*fn)"
-    maybeAddName(c, name)
-    c.add ParRi
+    if lastCallConv != Empty:
+      c.add CallingConvToStr[lastCallConv]
+      c.add "_PTR"
+      c.add ParLe
+      if types[decl.returnType].kind == Empty:
+        c.add "void"
+      else:
+        genType c, types, decl.returnType
+      c.add Comma
+      genProcTypePragmas c, types, decl.pragmas, isVarargs
+      maybeAddName(c, name)
+      c.add ParRi
+    else:
+      if types[decl.returnType].kind == Empty:
+        c.add "void"
+      else:
+        genType c, types, decl.returnType
+      c.add Space
+      c.add ParLe
+      genProcTypePragmas c, types, decl.pragmas, isVarargs
+      c.add Star # "(*fn)"
+      maybeAddName(c, name)
+      c.add ParRi
     c.add ParLe
     var i = 0
     for ch in sons(types, decl.params):

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -156,6 +156,13 @@
     (call assert.c (eq (suf +18446744073709551615u "u64") +18446744073709551615u))
   ))
 
+  (type :FooProc.cdecl . (proctype . (params) (i +32) (pragmas (cdecl))))
+  (type :FooProc.stdcall . (proctype . (params) (i +32) (pragmas (stdcall))))
+  (type :FooProc.safecall . (proctype . (params) (i +32) (pragmas (safecall))))
+  (type :FooProc.fastcall . (proctype . (params) (i +32) (pragmas (fastcall))))
+  (type :FooProc.noconv . (proctype . (params) (i +32) (pragmas (noconv))))
+  (type :FooProc.member . (proctype . (params) (i +32) (pragmas (member))))
+
   (proc :foo.inline . (i +32) (pragmas (inline)) (stmts
     (ret +1)
   ))
@@ -250,6 +257,12 @@
     (call foo.fastcall)
     (call foo.noconv)
     (call foo.member)
+    (var :foovar.cdecl . FooProc.cdecl foo.cdecl)
+    (var :foovar.stdcall . FooProc.stdcall foo.stdcall)
+    (var :foovar.safecall . FooProc.safecall foo.safecall)
+    (var :foovar.fastcall . FooProc.fastcall foo.fastcall)
+    (var :foovar.noconv . FooProc.noconv foo.noconv)
+    (var :foovar.member . FooProc.member foo.member)
 
     (var :x.c . (i +8) (suf +12 "i8"))
     (discard x.c)


### PR DESCRIPTION
This is what Nim uses, it might cause issues when adding attributes (currently it does `typedef void (*__attribute(foo)__ bar)` unilke no call convention which does `typedef void (__attribute__(foo) *bar)`) but this can be addressed when attributes are used for proc types, I can't find an example of either version working.