### PR TITLE
gear3: implements enumT

### DIFF
--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -176,6 +176,28 @@ proc traverseTupleField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {
   inc c # skips value
   wantParRi e, c
 
+proc traverseEnumField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}): TokenBuf =
+  e.dest.add c # efld
+  inc c
+
+  expectSymdef(e, c)
+  let (s, sinfo) = getSymDef(e, c)
+  e.dest.add toToken(SymbolDef, s, sinfo)
+  e.offer s
+
+  skipExportMarker e, c
+
+  inc c # pragmas: must be empty
+
+  result = createTokenBuf()
+
+  swap(e.dest, result)
+  traverseType e, c, flags
+  swap(result, e.dest)
+
+  traverseExpr e, c
+  wantParRi e, c
+
 proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
   case c.kind
   of DotToken:
@@ -231,7 +253,23 @@ proc traverseType(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}) =
         traverseTupleField(e, c, flags)
 
       wantParRi e, c
-    of ObjectT, EnumT, VoidT, StringT, VarargsT, NilT, ConceptT,
+    of EnumT:
+      e.dest.add c
+      inc c
+
+      var fields = createTokenBuf()
+      var commonType = createTokenBuf()
+
+      swap(e.dest, fields)
+      while c.substructureKind == EfldS:
+        commonType = traverseEnumField(e, c, flags)
+      swap(fields, e.dest)
+
+      e.dest.add commonType
+      e.dest.add fields
+
+      wantParRi e, c
+    of ObjectT, VoidT, StringT, VarargsT, NilT, ConceptT,
        IterT, InvokeT, SetT:
       error e, "unimplemented type: ", c
   else:

--- a/src/gear3/expander.nim
+++ b/src/gear3/expander.nim
@@ -187,7 +187,7 @@ proc traverseEnumField(e: var EContext; c: var Cursor; flags: set[TypeFlag] = {}
 
   skipExportMarker e, c
 
-  inc c # pragmas: must be empty
+  skip c # pragmas: must be empty
 
   result = createTokenBuf()
 

--- a/tests/gear3/gear3_helloworld.nif
+++ b/tests/gear3/gear3_helloworld.nif
@@ -9,6 +9,15 @@
     (fld :b.0.tesg7afhq1 . . ~22,~6
       (i -1) .)))
 
+ (type ~6 :Color.0.tesg7afhq1 . . . 2
+  (enum ,1
+   (efld ~6 :Red.0.tesg7afhq1 . .
+    (i -1) +0) 10,1
+   (efld ~7 :Blue.0.tesg7afhq1 . .
+    (i -1) +1) 21,1
+   (efld ~8 :Green.0.tesg7afhq1 . .
+    (i -1) +2)))
+
 
   (var :x . . (i +32) +12)
   (var :y . . (i +32) +12)


### PR DESCRIPTION
implements `enumT`: adds an extra parameter `dest: var TokenBuf` for `traverseExpr`, `loop`, `traverseType` etc. Because we need to evaluate fields in advance for later use to get the enum types, the result of fields need to be stored in a temp `TokenBuf`.