### PR TITLE
nimony: tuple constructors

### DIFF
--- a/src/nimony/builtintypes.nim
+++ b/src/nimony/builtintypes.nim
@@ -14,6 +14,7 @@ type
     int8Type*, int16Type*, int32Type*, int64Type*: Cursor
     uint8Type*, uint16Type*, uint32Type*, uint64Type*: Cursor
     float32Type*, float64Type*: Cursor
+    emptyTupleType*: Cursor
 
 proc tagToken(tag: string; info: PackedLineInfo = NoLineInfo): PackedToken {.inline.} =
   toToken(ParLe, pool.tags.getOrIncl(tag), info)
@@ -70,7 +71,9 @@ proc createBuiltinTypes*(): BuiltinTypes =
 
   addBitsType "f", 32 # 45
   addBitsType "f", 64 # 48
-  # next would be 51
+
+  result.mem.add tagToken"tuple" # 51
+  result.mem.addParRi() # 52
 
   result.mem.freeze()
 
@@ -93,3 +96,4 @@ proc createBuiltinTypes*(): BuiltinTypes =
   result.uint64Type = result.mem.cursorAt(42)
   result.float32Type = result.mem.cursorAt(45)
   result.float64Type = result.mem.cursorAt(48)
+  result.emptyTupleType = result.mem.cursorAt(51)

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2429,7 +2429,7 @@ proc semArrayConstr(c: var SemContext, it: var Item) =
   c.dest.buildTree ArrayT, it.n.info:
     c.dest.add toToken(IntLit, count, it.n.info)
     c.dest.addSubtree elem.typ
-  combineType c, it.n.info, it.typ, typeToCursor(c, start)
+  commonType c, it, start, it.typ
   c.dest.shrink start
 
 proc isRangeNode(c: var SemContext; n: Cursor): bool =
@@ -2475,7 +2475,7 @@ proc semSetConstr(c: var SemContext, it: var Item) =
   let start = c.dest.len
   c.dest.buildTree SetT, it.n.info:
     c.dest.addSubtree elem.typ
-  combineType c, it.n.info, it.typ, typeToCursor(c, start)
+  commonType c, it, start, it.typ
   c.dest.shrink start
 
 proc semSuf(c: var SemContext, it: var Item) =
@@ -2555,7 +2555,7 @@ proc semTupleConstr(c: var SemContext, it: var Item) =
   let start = c.dest.len
   var t = typ.cursorAt(0)
   semTupleType(c, t)
-  combineType c, it.n.info, it.typ, typeToCursor(c, start)
+  commonType c, it, start, it.typ
   c.dest.shrink start
 
 proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =

--- a/src/nimony/tests/basics/t1.nim
+++ b/src/nimony/tests/basics/t1.nim
@@ -103,3 +103,7 @@ proc ifExpr(): int =
 var x = [1, 2, 3]
 let u8 = 3'u8
 let y = {1'u8, u8, 5'u8, 7'u8..9'u8}
+var z = (1, "abc")
+z = (2, "def")
+var t: tuple[x: int, y: string] = (1, "abc")
+t = (x: 2, y: "def")


### PR DESCRIPTION
Typedesc tuples aren't implemented (i.e. `(int, string)`), they could be but it would hinge on type expressions being accepted as regular expressions, which is not the case currently but probably should be eventually. Then we would check for `TypedescT`.