### PR TITLE
nimony: fix wrong uses of commonType, use for syms, dot, `suf`

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1522,6 +1522,8 @@ type
     OrdinaryDot, AlsoTryDotCall, DotDontReportError
 
 proc semDot(c: var SemContext; it: var Item; mode: DotExprMode) =
+  let exprStart = c.dest.len
+  let expected = it.typ
   takeToken c, it.n
   var a = Item(n: it.n, typ: c.types.autoType)
   semExpr c, a
@@ -1540,8 +1542,7 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode) =
         if field.level >= 0:
           c.dest.add toToken(Symbol, field.sym, info)
           c.dest.add toToken(IntLit, pool.integers.getOrIncl(field.level), info)
-          combineType c, info, it.typ, field.typ
-          # XXX use commonType here
+          it.typ = field.typ # will be fit later with commonType
           it.kind = FldY
           isMatch = true
         else:
@@ -1554,6 +1555,8 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode) =
   if it.n.kind == IntLit:
     inc it.n
   wantParRi c, it.n
+  if isMatch:
+    commonType c, it, exprStart, expected
 
 proc semWhile(c: var SemContext; it: var Item) =
   let info = it.n.info

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -375,7 +375,7 @@ proc singleArg(m: var Match; f: var Cursor; arg: Item) =
       else:
         linearMatch m, f, a
       expectParRi m, f
-    of ArrayT:
+    of ArrayT, SetT:
       var a = skipModifier(arg.typ)
       linearMatch m, f, a
       expectParRi m, f
@@ -385,9 +385,11 @@ proc singleArg(m: var Match; f: var Cursor; arg: Item) =
       linearMatch m, f, a
       expectParRi m, f
     of TupleT:
-      var a = arg.typ
+      let fOrig = f
+      let aOrig = arg.typ
+      var a = aOrig
       if a.typeKind != TupleT:
-        m.error expected(f, a)
+        m.error expected(fOrig, aOrig)
         skip f
       else:
         # skip tags:
@@ -396,7 +398,7 @@ proc singleArg(m: var Match; f: var Cursor; arg: Item) =
         while f.kind != ParRi:
           if a.kind == ParRi:
             # len(f) > len(a)
-            m.error expected(f, a)
+            m.error expected(fOrig, aOrig)
           # only the type of the field is important:
           var ffld = asLocal(f).typ
           var afld = asLocal(a).typ
@@ -406,7 +408,7 @@ proc singleArg(m: var Match; f: var Cursor; arg: Item) =
           skip a
         if a.kind != ParRi:
           # len(a) > len(f)
-          m.error expected(f, a)
+          m.error expected(fOrig, aOrig)
     else:
       m.error "BUG: unhandled type: " & pool.tags[f.tagId]
   else:


### PR DESCRIPTION
The only remaining use of `combineType` is `producesVoid`/`producesNoReturn`, which just check that `void` or `auto` were expected (and noreturn assimilates into the expected type otherwise).