### PR TITLE
nimony: expression evaluator for simple constant expressions

### DIFF
--- a/src/nimony/expreval.nim
+++ b/src/nimony/expreval.nim
@@ -1,0 +1,145 @@
+## expression evaluator for simple constant expressions, not meant to be complete
+## 
+## included in sem.nim
+
+type EvalContext = object
+  c: ptr SemContext # used the same way as `var SemContext`
+  values: seq[TokenBuf]
+  trueValue, falseValue: Cursor
+
+proc isConstBoolValue(n: Cursor): bool =
+  n.exprKind in {TrueX, FalseX}
+
+proc isConstIntValue(n: Cursor): bool =
+  n.kind == IntLit
+
+proc isConstUIntValue(n: Cursor): bool =
+  n.kind == UIntLit
+
+proc isConstStringValue(n: Cursor): bool =
+  n.kind == StringLit
+
+proc isConstCharValue(n: Cursor): bool =
+  n.kind == CharLit
+
+proc initEvalContext(c: var SemContext): EvalContext =
+  result = EvalContext(c: addr c, values: @[])
+
+proc error(c: var EvalContext, msg: string, info: PackedLineInfo): Cursor =
+  c.values.add createTokenBuf(3)
+  c.values[^1].addParLe ErrT, info
+  c.values[^1].addStrLit msg
+  c.values[^1].addParRi()
+  result = cursorAt(c.values[^1], 0)
+
+proc getTrueValue(c: var EvalContext): Cursor =
+  if c.trueValue == default(Cursor):
+    let i = c.values.len
+    c.values[i].add toToken(ParLe, TrueX, NoLineInfo)
+    c.values[i].addParRi()
+    c.trueValue = cursorAt(c.values[i], 0)
+  result = c.trueValue
+
+proc getFalseValue(c: var EvalContext): Cursor =
+  if c.falseValue == default(Cursor):
+    let i = c.values.len
+    c.values[i].add toToken(ParLe, FalseX, NoLineInfo)
+    c.values[i].addParRi()
+    c.falseValue = cursorAt(c.values[i], 0)
+  result = c.falseValue
+
+proc eval(c: var EvalContext, n: var Cursor): Cursor =
+  template error(msg: string, info: PackedLineInfo) =
+    result = c.error(msg, info)
+  template propagateError(r: Cursor): Cursor =
+    let val = r
+    if val.kind == ParLe and val.tagId == ErrT:
+      val
+    else:
+      return val
+  case n.kind
+  of Ident:
+    error "cannot evaluate undeclared ident: " & pool.strings[n.litId], n.info
+    inc n
+  of Symbol:
+    case n.symKind
+    of ConstY:
+      let sym = tryLoadSym(n.symId)
+      if sym.status == LacksNothing:
+        result = asLocal(sym.decl).val
+        inc n
+        return
+    else: discard
+    error "cannot evaluate symbol at compile time: " & pool.syms[n.symId], n.info
+    inc n
+  of StringLit, CharLit, IntLit, UIntLit, FloatLit:
+    result = n
+    inc n
+  of ParLe:
+    case n.exprKind
+    of TrueX, FalseX:
+      result = n
+      skip n
+    of AndX:
+      inc n
+      let a = propagateError eval(c, n)
+      if a.exprKind == FalseX:
+        skipToEnd n
+        return a
+      elif a.exprKind != TrueX:
+        error "expected bool for operand of `and` but got: " & toString(a, false), n.info
+        return
+      let b = propagateError eval(c, n)
+      if not isConstBoolValue(b):
+        error "expected bool for operand of `and` but got: " & toString(b, false), n.info
+        return
+      else:
+        skipParRi n
+        return b
+    of OrX:
+      inc n
+      let a = propagateError eval(c, n)
+      if a.exprKind == TrueX:
+        skipToEnd n
+        return a
+      elif a.exprKind != FalseX:
+        error "expected bool for operand of `or` but got: " & toString(a, false), n.info
+        return
+      let b = propagateError eval(c, n)
+      if not isConstBoolValue(b):
+        error "expected bool for operand of `or` but got: " & toString(b, false), n.info
+        return
+      else:
+        skipParRi n
+        return b
+    of NotX:
+      inc n
+      let a = propagateError eval(c, n)
+      if a.exprKind == TrueX:
+        skipParRi n
+        return c.getFalseValue()
+      elif a.exprKind == FalseX:
+        skipParRi n
+        return c.getTrueValue()
+      else:
+        error "expected bool for operand of `not` but got: " & toString(a, false), n.info
+        return
+    of SufX:
+      # we only need raw value
+      inc n
+      result = n
+      skipToEnd n
+    else:
+      if n.tagId == ErrT:
+        result = n
+        skip n
+      else:
+        error "cannot evaluate expression at compile time: " & toString(n, false), n.info
+  else:
+    error "cannot evaluate expression at compile time: " & toString(n, false), n.info
+
+proc evalExpr(c: var SemContext, n: var Cursor): TokenBuf =
+  var ec = initEvalContext(c)
+  let val = eval(ec, n)
+  result = createTokenBuf(val.span)
+  result.addSubtree val

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -12,7 +12,7 @@ import std / [tables, sets, syncio, formatfloat, assertions]
 include nifprelude
 import nimony_model, symtabs, builtintypes, decls, symparser,
   programs, sigmatch, magics, reporters, nifconfig, nifindexes,
-  semdata, semos
+  semdata, semos, expreval
 
 import ".." / gear2 / modnames
 
@@ -526,8 +526,6 @@ proc wantDot(c: var SemContext; n: var Cursor) =
 
 # ------------------ include/import handling ------------------------
 
-include expreval
-
 proc semStmt(c: var SemContext; n: var Cursor)
 
 proc typeMismatch(c: var SemContext; info: PackedLineInfo; got, expected: TypeCursor) =
@@ -983,7 +981,7 @@ proc semConstBoolExpr(c: var SemContext; n: var Cursor) =
   if classifyType(c, it.typ) != BoolT:
     buildErr c, it.n.info, "expected `bool` but got: " & typeToString(it.typ)
   var e = cursorAt(c.dest, start)
-  var valueBuf = evalExpr(c, e)
+  var valueBuf = evalExpr(e)
   endRead(c.dest)
   let value = cursorAt(valueBuf, 0)
   if not isConstBoolValue(value):
@@ -1003,7 +1001,7 @@ proc semConstStrExpr(c: var SemContext; n: var Cursor) =
   if classifyType(c, it.typ) != StringT:
     buildErr c, it.n.info, "expected `string` but got: " & typeToString(it.typ)
   var e = cursorAt(c.dest, start)
-  var valueBuf = evalExpr(c, e)
+  var valueBuf = evalExpr(e)
   endRead(c.dest)
   let value = cursorAt(valueBuf, 0)
   if not isConstStringValue(value):
@@ -1023,7 +1021,7 @@ proc semConstIntExpr(c: var SemContext; n: var Cursor) =
   if classifyType(c, it.typ) != IntT:
     buildErr c, it.n.info, "expected `int` but got: " & typeToString(it.typ)
   var e = cursorAt(c.dest, start)
-  var valueBuf = evalExpr(c, e)
+  var valueBuf = evalExpr(e)
   endRead(c.dest)
   let value = cursorAt(valueBuf, 0)
   if not isConstIntValue(value):


### PR DESCRIPTION
This acts as a primitive version of the compile time VM so that we can handle the most common constant expressions in Nim code. I had thought `defined`/`declared` would also be evaluated here, but currently they are immediately resolved in semchecking, which could be sufficient overall including for things like `sizeof` (though not when they depend on an unresolved generic parameter i.e. `sizeof(T)`, but this would be resolved in semchecking during instantiation too).

Might be ugly and low on comments, couldn't think of how to clean it up. `semConstBoolExpr` is unused for now but will likely be used.