### PR TITLE
nifc: fixes enums

### DIFF
--- a/src/nifc/gentypes.nim
+++ b/src/nifc/gentypes.nim
@@ -327,10 +327,17 @@ proc genObjectOrUnionBody(c: var GeneratedCode; types: TypeGraph; n: NodePos) =
       c.add Semicolon
     else: discard
 
-proc genEnumDecl(c: var GeneratedCode; t: TypeGraph; n: NodePos) =
+proc genEnumDecl(c: var GeneratedCode; t: TypeGraph; n: NodePos; name: string) =
   # (efld SymbolDef Expr)
   # EnumDecl ::= (enum Type EnumFieldDecl+)
   let baseType = n.firstSon
+  c.add TypedefKeyword
+  c.genType t, baseType
+  c.add Space
+  c.add name
+  c.add Semicolon
+  c.add NewLine
+
   for ch in sonsFromX(t, n):
     if t[ch].kind == EfldC:
       let (a, b) = sons2(t, ch)
@@ -384,7 +391,7 @@ proc generateTypes(c: var GeneratedCode; types: TypeGraph; o: TypeOrder) =
         c.add s
         c.add Semicolon
       of EnumC:
-        genEnumDecl c, types, decl.body
+        genEnumDecl c, types, decl.body, s
       of ProctypeC:
         c.add TypedefKeyword
         genType c, types, decl.body, s

--- a/tests/nifc/issues.nif
+++ b/tests/nifc/issues.nif
@@ -12,6 +12,11 @@
   )
   )
 
+  (type ~6 :bool.0.tesg7afhq1 . 2
+  (enum 12,1 (u +8) 2,1
+   (efld ~8 :false.0.tesg7afhq1 +0) 12,1
+   (efld ~7 :true.0.tesg7afhq1 +1))) ,13
+
   (type :MyObject3.m .
   (object . (fld :a1 . (i +32 (atomic)))
     (fld :a2 . (i +64 (atomic)))
@@ -298,6 +303,8 @@
     (call assert.c (eq s.cpp +3))
 
     (call foo.escaped)
+
+    (var :x.0 . 6,~3 bool.0.tesg7afhq1 4 false.0.tesg7afhq1)
 
     (ret +0)
   ))


### PR DESCRIPTION
Adds a typedef for enum types: `typedef NU8 bool_0_tesg7afhq1;`