### PR TITLE
nimony: make commonType always give expected type

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -680,8 +680,7 @@ proc commonType(c: var SemContext; it: var Item; argBegin: int; expected: TypeCu
   else:
     shrink c.dest, argBegin
     c.dest.add m.args
-    if m.usesConversion:
-      it.typ = expected
+    it.typ = expected
 
 proc producesVoid(c: var SemContext; info: PackedLineInfo; dest: var Cursor) =
   if typeKind(dest) in {AutoT, VoidT}:


### PR DESCRIPTION
As mentioned in #197. The cases I can think of where the received type can subsume the expected type would be generic typeclasses or `auto`, but these aren't encountered here since typevars aren't set (`auto` is handled as a special case first). And these would probably need a separate instantiation mechanism if they were encountered. So unless we can think of other cases where this happens, it's simpler to always use the expected type as a general rule.