### PR TITLE
nimony: subscripts with invocations as special case

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2616,6 +2616,36 @@ proc semDeclared(c: var SemContext; it: var Item) =
   it.typ = c.types.boolType
   commonType c, it, beforeExpr, expected
 
+proc semSubscript(c: var SemContext; it: var Item) =
+  var n = it.n
+  inc n # tag
+  var lhsBuf = createTokenBuf(4)
+  swap c.dest, lhsBuf
+  var lhs = Item(n: n, typ: c.types.autoType)
+  semExpr c, lhs, {KeepMagics}
+  swap c.dest, lhsBuf
+  if lhs.n.kind == Symbol and lhs.kind == TypeY and
+      getTypeSection(lhs.n.symId).typevars == "typevars":
+    # lhs is a generic type symbol, this is a generic invocation
+    # treat it as a type expression to call semInvoke
+    semLocalTypeExpr c, it
+    return
+  # XXX also check for proc generic instantiation, including symchoice
+
+  # build call:
+  var callBuf = createTokenBuf(16)
+  callBuf.addParLe(CallX, it.n.info)
+  callBuf.add toToken(Ident, pool.strings.getOrIncl("[]"), it.n.info)
+  callBuf.add lhsBuf
+  it.n = lhs.n
+  while it.n.kind != ParRi:
+    callBuf.addSubtree it.n
+    skip it.n
+  callBuf.addParRi()
+  skipParRi it.n
+  var call = Item(n: cursorAt(callBuf, 0), typ: it.typ)
+  semExpr c, call
+
 proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
   case it.n.kind
   of IntLit:
@@ -2743,7 +2773,9 @@ proc semExpr(c: var SemContext; it: var Item; flags: set[SemFlag] = {}) =
       semDefined c, it
     of DeclaredX:
       semDeclared c, it
-    of AtX, DerefX, PatX, AddrX, NilX, SizeofX, OconstrX, KvX,
+    of AtX:
+      semSubscript c, it
+    of DerefX, PatX, AddrX, NilX, SizeofX, OconstrX, KvX,
        CastX, ConvX, RangeX, RangesX,
        HderefX, HaddrX, OconvX, HconvX, OchoiceX, CchoiceX,
        CompilesX, HighX, LowX, TypeofX, UnpackX:

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -2639,8 +2639,7 @@ proc semSubscript(c: var SemContext; it: var Item) =
   callBuf.add lhsBuf
   it.n = lhs.n
   while it.n.kind != ParRi:
-    callBuf.addSubtree it.n
-    skip it.n
+    callBuf.takeTree it.n
   callBuf.addParRi()
   skipParRi it.n
   var call = Item(n: cursorAt(callBuf, 0), typ: it.typ)


### PR DESCRIPTION
As outlined [here](https://github.com/nim-lang/nif/pull/194/#issuecomment-2538356468), would also have a special case for generic routines but there is nothing to call for them yet. Anything that is not an invocation is treated as an overloaded call to `[]`, which needs to have magic overloads.

Note for the future: https://github.com/nim-lang/Nim/issues/9997, standalone instantiations of symchoices shouldn't generate a symchoice of the instantiated symbols as Nim currently does, instead it should probably be treated as an "instantiation choice" either remaining as a bracket over a symchoice or its own node kind that can later be type-fit to a specific instantiation