### PR TITLE
nimony: implement UFCS

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -841,12 +841,12 @@ proc semCall(c: var SemContext; it: var Item) =
       # add a as argument:
       let lhsIndex = c.dest.len
       c.dest.addSubtree lhs.n
-      # arg.n will be set by argIndexes:
       argIndexes.add lhsIndex
       # scope extension: If the type is Typevar and it has attached
       # a concept, use the concepts symbols too:
       if fnName != StrId(0) and lhs.typ.kind == Symbol:
         maybeAddConceptMethods c, fnName, lhs.typ.symId, candidates
+      # lhs.n escapes here, but is not read and will be set by argIndexes:
       args.add lhs
   else:
     semExpr(c, fn, {KeepMagics})

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -976,13 +976,9 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode): DotExprState =
           it.kind = FldY
           result = MatchedDot
         else:
-          swap c.dest, failedMatchError
-          c.buildErr it.n.info, "undeclared field: " & pool.strings[fieldName]
-          swap c.dest, failedMatchError
+          c.buildErr failedMatchError, it.n.info, "undeclared field: " & pool.strings[fieldName]
       else:
-        swap c.dest, failedMatchError
-        c.buildErr it.n.info, "object type exptected"
-        swap c.dest, failedMatchError
+        c.buildErr failedMatchError, it.n.info, "object type exptected"
     elif t.typeKind == TupleT:
       var tup = t
       inc tup
@@ -997,13 +993,9 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode): DotExprState =
         skip tup
       c.dest.add intToken(pool.integers.getOrIncl(0), info)
       if result != MatchedDot:
-        swap c.dest, failedMatchError
-        c.buildErr it.n.info, "undeclared field: " & pool.strings[fieldName]
-        swap c.dest, failedMatchError
+        c.buildErr failedMatchError, it.n.info, "undeclared field: " & pool.strings[fieldName]
     else:
-      swap c.dest, failedMatchError
-      c.buildErr it.n.info, "object type exptected"
-      swap c.dest, failedMatchError
+      c.buildErr failedMatchError, it.n.info, "object type exptected"
   # skip optional inheritance depth:
   if it.n.kind == IntLit:
     inc it.n
@@ -1019,14 +1011,14 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode): DotExprState =
       c.dest.add failedMatchError
       wantParRi c, it.n
     of CalleeDot:
-      c.dest.add toToken(Ident, fieldName, info)
+      c.dest.add identToken(fieldName, info)
       wantParRi c, it.n
       it.typ = a.typ # store info of lhs type
     of AlsoTryDotCall:
       skipParRi it.n
       var callBuf = createTokenBuf(16)
       callBuf.addParLe(CallX, info)
-      callBuf.add toToken(Ident, fieldName, info)
+      callBuf.add identToken(fieldName, info)
       callBuf.addSubtree cursorAt(c.dest, exprStart + 1) # add lhs as first argument
       endRead(c.dest)
       callBuf.addParRi()

--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1526,6 +1526,7 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode): DotExprState =
       c.dest.add failedMatchError
       wantParRi c, it.n
     of CalleeDot:
+      c.dest.add toToken(Ident, fieldName, info)
       wantParRi c, it.n
       it.typ = a.typ # store info of lhs type
     of AlsoTryDotCall:

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -214,15 +214,18 @@ template withErrorContext*(c: var SemContext; info: PackedLineInfo; body: untype
   finally:
     popErrorContext(c)
 
-proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string) =
+proc buildErr*(c: var SemContext; buf: var TokenBuf; info: PackedLineInfo; msg: string) =
   when defined(debug):
     writeStackTrace()
     echo infoToStr(info) & " Error: " & msg
     quit msg
-  c.dest.buildTree ErrT, info:
+  buf.buildTree ErrT, info:
     for instFrom in items(c.instantiatedFrom):
-      c.dest.add dotToken(instFrom)
-    c.dest.add strToken(pool.strings.getOrIncl(msg), info)
+      buf.add dotToken(instFrom)
+    buf.add strToken(pool.strings.getOrIncl(msg), info)
+
+proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string) {.inline.} =
+  c.buildErr(c.dest, info, msg)
 
 proc buildLocalErr*(dest: var TokenBuf; info: PackedLineInfo; msg: string) =
   when defined(debug):

--- a/src/nimony/sembasics.nim
+++ b/src/nimony/sembasics.nim
@@ -214,18 +214,15 @@ template withErrorContext*(c: var SemContext; info: PackedLineInfo; body: untype
   finally:
     popErrorContext(c)
 
-proc buildErr*(c: var SemContext; buf: var TokenBuf; info: PackedLineInfo; msg: string) =
+proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string) =
   when defined(debug):
     writeStackTrace()
     echo infoToStr(info) & " Error: " & msg
     quit msg
-  buf.buildTree ErrT, info:
+  c.dest.buildTree ErrT, info:
     for instFrom in items(c.instantiatedFrom):
-      buf.add dotToken(instFrom)
-    buf.add strToken(pool.strings.getOrIncl(msg), info)
-
-proc buildErr*(c: var SemContext; info: PackedLineInfo; msg: string) {.inline.} =
-  c.buildErr(c.dest, info, msg)
+      c.dest.add dotToken(instFrom)
+    c.dest.add strToken(pool.strings.getOrIncl(msg), info)
 
 proc buildLocalErr*(dest: var TokenBuf; info: PackedLineInfo; msg: string) =
   when defined(debug):

--- a/src/nimony/tests/basics/t1.nim
+++ b/src/nimony/tests/basics/t1.nim
@@ -39,12 +39,12 @@ var global: MyObject
 
 global.x = 45
 discard foo(global.x, "123")
-#discard global.x.foo("123")
+discard global.x.foo("123")
 
 overloaded()
 overloaded("abc")
 "abc".overloaded
-#"abc".overloaded()
+"abc".overloaded()
 
 proc discardable(x: int): int {.discardable.} =
   result = x + 7

--- a/src/nimony/tests/basics/t1.nim
+++ b/src/nimony/tests/basics/t1.nim
@@ -39,9 +39,12 @@ var global: MyObject
 
 global.x = 45
 discard foo(global.x, "123")
+#discard global.x.foo("123")
 
 overloaded()
 overloaded("abc")
+"abc".overloaded
+#"abc".overloaded()
 
 proc discardable(x: int): int {.discardable.} =
   result = x + 7

--- a/src/nimony/tests/basics/tgeneric_obj.nif
+++ b/src/nimony/tests/basics/tgeneric_obj.nif
@@ -27,9 +27,9 @@
  (var :myglob.0.tge6t2h7f . . 17 MyGeneric.1.tge6t2h7f .) 2,14
  (var :other.0.tge6t2h7f . . 16 MyGeneric.2.tge6t2h7f .) 9,16
  (asgn ~3
-  (dot ~6 myglob.0.tge6t2h7f 1 x.1.tge6t2h7f 1 +0) 2 +56) 8,17
+  (dot ~6 myglob.0.tge6t2h7f x.1.tge6t2h7f +0) 2 +56) 8,17
  (asgn ~3
-  (dot ~5 other.0.tge6t2h7f 1 x.2.tge6t2h7f 1 +0) 2 +79.0) ,19
+  (dot ~5 other.0.tge6t2h7f x.2.tge6t2h7f +0) 2 +79.0) ,19
  (proc 5 :\2B.0.tge6t2h7f 
   (add -3) . . 9
   (params 1

--- a/src/nimony/tests/basics/ttemplate.nif
+++ b/src/nimony/tests/basics/ttemplate.nif
@@ -27,9 +27,9 @@
  (var :myglob.0.tteoes9tj1 . . 17 MyGeneric.1.tteoes9tj1 .) 2,14
  (var :other.0.tteoes9tj1 . . 16 MyGeneric.2.tteoes9tj1 .) 9,16
  (asgn ~3
-  (dot ~6 myglob.0.tteoes9tj1 1 x.1.tteoes9tj1 1 +0) 2 +56) 8,17
+  (dot ~6 myglob.0.tteoes9tj1 x.1.tteoes9tj1 +0) 2 +56) 8,17
  (asgn ~3
-  (dot ~5 other.0.tteoes9tj1 1 x.2.tteoes9tj1 1 +0) 2 +79.0) ,19
+  (dot ~5 other.0.tteoes9tj1 x.2.tteoes9tj1 +0) 2 +79.0) ,19
  (proc 5 :\2B.0.tteoes9tj1 
   (add -3) . . 9
   (params 1


### PR DESCRIPTION
Calls special case dot expression callees on a syntax level, if the dot expression ends up not being a builtin dot or being a builtin dot that doesn't have a proc type, the callee is rebuilt from the field identifier and the LHS of the dot is added as an argument. Standalone dot expressions that don't resolve to a builtin dot are also transformed into a call and semchecked as such.

This is achieved by moving the previous behavior of `semDot` into `tryBuiltinDot` which takes an already built LHS cursor and a field name identifier and builds a dot expression on `c.dest`, then returns the status of whether the dot expression was a builtin or not.