### PR TITLE
nimony: fixes dot access for tupleT

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1460,6 +1460,7 @@ proc semDot(c: var SemContext; it: var Item; mode: DotExprMode) =
           isMatch = true
           break
         skip tup
+      c.dest.add toToken(IntLit, pool.integers.getOrIncl(0), info)
       if not isMatch:
         c.buildErr it.n.info, "undeclared field: " & pool.strings[fieldName]
     else:


### PR DESCRIPTION
keeps it consistent with ObjectT: since nifc specifies `(dot Expr Symbol Number)` for field accesses