### PR TITLE
nimony: implement invocations of magic types (array, set etc)

### DIFF
--- a/src/nimony/sem.nim
+++ b/src/nimony/sem.nim
@@ -1306,6 +1306,7 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
 
   var headId: SymId = SymId(0)
   var decl = default TypeDecl
+  var magicKind = NoType
   var ok = false
   if c.dest[typeStart+1].kind == Symbol:
     headId = c.dest[typeStart+1].symId
@@ -1317,7 +1318,17 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     else:
       ok = true
   else:
-    c.buildErr info, "cannot attempt to instantiate a non-type"
+    # symbol may have inlined into a magic
+    let head = cursorAt(c.dest, typeStart+1)
+    let kind = head.typeKind
+    endRead(c.dest)
+    if kind in {ArrayT, VarargsT,
+      PtrT, RefT, UncheckedArrayT, SetT, StaticT, TypedescT}:
+      # magics that can be invoked
+      magicKind = kind
+      ok = true
+    else:
+      c.buildErr info, "cannot attempt to instantiate a non-type"
 
   var genericArgs = 0
   swap c.usedTypevars, genericArgs
@@ -1333,8 +1344,38 @@ proc semInvoke(c: var SemContext; n: var Cursor) =
     if c.instantiatedTypes.hasKey(key):
       c.dest.add symToken(c.instantiatedTypes[key], info)
     else:
-      let targetSym = newSymId(c, headId)
       var args = cursorAt(c.dest, beforeArgs)
+      if magicKind != NoType:
+        var magicExpr = createTokenBuf(8)
+        magicExpr.addParLe(magicKind, info)
+        # reorder invocation according to type specifications:
+        case magicKind
+        of ArrayT:
+          # invoked as array[len, elem], but needs to become (array elem len)
+          let indexPart = args
+          skip args
+          magicExpr.takeTree args # element type
+          magicExpr.addSubtree indexPart
+          skipParRi args
+        of PtrT, RefT, UncheckedArrayT, SetT, StaticT, TypedescT:
+          # unary invocations
+          magicExpr.takeTree args
+          skipParRi args
+        of VarargsT:
+          magicExpr.takeTree args
+          if args.kind != ParRi:
+            # optional varargs call
+            magicExpr.takeTree args
+          skipParRi args
+        else:
+          raiseAssert "unreachable" # see type kind check for magicKind
+        magicExpr.addParRi()
+        c.dest.endRead()
+        c.dest.shrink typeStart
+        var m = cursorAt(magicExpr, 0)
+        semLocalTypeImpl c, m, InLocalDecl
+        return
+      let targetSym = newSymId(c, headId)
       var instance = createTokenBuf(30)
       instGenericType c, instance, info, headId, targetSym, decl, args
       c.dest.endRead()
@@ -1433,7 +1474,12 @@ proc semLocalTypeImpl(c: var SemContext; n: var Cursor; context: TypeDeclContext
     else:
       c.buildErr info, "not a type"
   else:
-    c.buildErr info, "not a type"
+    if context == AllowValues:
+      var it = Item(n: n, typ: c.types.autoType)
+      semExpr c, it
+      n = it.n
+    else:
+      c.buildErr info, "not a type"
 
 proc semLocalType(c: var SemContext; n: var Cursor; context = InLocalDecl): TypeCursor =
   let insertPos = c.dest.len

--- a/src/nimony/sigmatch.nim
+++ b/src/nimony/sigmatch.nim
@@ -170,7 +170,7 @@ proc isTypevar(s: SymId): bool =
   let typevar = asTypevar(res.decl)
   result = typevar.kind == TypevarY
 
-proc linearMatch(m: var Match; f, a: var Cursor) =
+proc linearMatch(m: var Match; f, a: var Cursor, containsStartTag = true) =
   var nested = 0
   while true:
     if f.kind == Symbol and isTypevar(f.symId):
@@ -199,7 +199,7 @@ proc linearMatch(m: var Match; f, a: var Cursor) =
           break
         inc nested
       of ParRi:
-        if nested == 0: break
+        if nested == ord(containsStartTag): break
         dec nested
     else:
       m.error expected(f, a)

--- a/src/nimony/tests/basics/tgeneric_obj.nif
+++ b/src/nimony/tests/basics/tgeneric_obj.nif
@@ -55,9 +55,9 @@
  (var :myglob.0.tge6t2h7f . . 17 MyGeneric.1.tge6t2h7f .) 2,22
  (var :other.0.tge6t2h7f . . 16 MyGeneric.2.tge6t2h7f .) 9,24
  (asgn ~3
-  (dot ~6 myglob.0.tge6t2h7f 1 x.1.tge6t2h7f 1 +0) 2 +56) 8,25
+  (dot ~6 myglob.0.tge6t2h7f x.1.tge6t2h7f +0) 2 +56) 8,25
  (asgn ~3
-  (dot ~5 other.0.tge6t2h7f 1 x.2.tge6t2h7f 1 +0) 2 +79.0) ,27
+  (dot ~5 other.0.tge6t2h7f x.2.tge6t2h7f +0) 2 +79.0) ,27
  (proc 5 :\2B.0.tge6t2h7f 
   (add -3) . . 9
   (params 1

--- a/src/nimony/tests/basics/tgeneric_obj.nif
+++ b/src/nimony/tests/basics/tgeneric_obj.nif
@@ -11,74 +11,102 @@
  (type :string.0.tge6t2h7f 
   (string) . 8
   (pragmas 2
-   (magic 7 String)) .) 2,6
+   (magic 7 String)) .) 2,5
+ (type :uint8.0.tge6t2h7f 
+  (u +8) . 7
+  (pragmas 2
+   (magic 7 UInt8)) .) 2,7
+ (type :set.0.tge6t2h7f 
+  (sett) 4
+  (typevars 1
+   (typevar :T.0 . . . .)) 8
+  (pragmas 2
+   (magic 7 Set)) .) 2,8
  (type :array.0.tge6t2h7f 
   (array) 7
   (typevars 1
    (typevar :Index.0 . . . .) 8
-   (typevar :T.0 . . . .)) 18
+   (typevar :T.1 . . . .)) 18
   (pragmas 2
-   (magic 7 Array)) .) 15,9
+   (magic 7 Array)) .) 4,10
+ (var :myset.0.tge6t2h7f . . 10
+  (sett ~12,~5
+   (u +8)) .) 4,11
+ (var :myarr.0.tge6t2h7f . . 12
+  (array ~14,~10
+   (i -1) 1 +3) .) 4,12
+ (let :u8.0.tge6t2h7f . .
+  (u +8) 5
+  (suf +3u "u8")) 6,13
+ (asgn ~6 myset.0.tge6t2h7f 2
+  (set 1
+   (suf +1u "u8") 7 u8.0.tge6t2h7f 11
+   (suf +5u "u8") 17
+   (range 
+    (suf +7u "u8") 6
+    (suf +9u "u8")))) 6,14
+ (asgn ~6 myarr.0.tge6t2h7f 2
+  (arr 1 +1 4 +2 7 +3)) 15,17
  (type ~13 :MyGeneric.0.tge6t2h7f . ~4
   (typevars 1
-   (typevar :T.1 . . . .)) . 2
+   (typevar :T.2 . . . .)) . 2
   (object . ~13,1
-   (fld :x.0.tge6t2h7f . . 3 T.1 .))) 2,13
- (var :myglob.0.tge6t2h7f . . 17 MyGeneric.1.tge6t2h7f .) 2,14
- (var :other.0.tge6t2h7f . . 16 MyGeneric.2.tge6t2h7f .) 9,16
+   (fld :x.0.tge6t2h7f . . 3 T.2 .))) 2,21
+ (var :myglob.0.tge6t2h7f . . 17 MyGeneric.1.tge6t2h7f .) 2,22
+ (var :other.0.tge6t2h7f . . 16 MyGeneric.2.tge6t2h7f .) 9,24
  (asgn ~3
-  (dot ~6 myglob.0.tge6t2h7f 1 x.1.tge6t2h7f 1 +0) 2 +56) 8,17
+  (dot ~6 myglob.0.tge6t2h7f 1 x.1.tge6t2h7f 1 +0) 2 +56) 8,25
  (asgn ~3
-  (dot ~5 other.0.tge6t2h7f 1 x.2.tge6t2h7f 1 +0) 2 +79.0) ,19
+  (dot ~5 other.0.tge6t2h7f 1 x.2.tge6t2h7f 1 +0) 2 +79.0) ,27
  (proc 5 :\2B.0.tge6t2h7f 
   (add -3) . . 9
   (params 1
-   (param :x.0 . . ~8,~18
+   (param :x.0 . . ~8,~26
     (i -1) .) 4
-   (param :y.0 . . ~11,~18
-    (i -1) .)) 2,~18
+   (param :y.0 . . ~11,~26
+    (i -1) .)) 2,~26
   (i -1) 26
   (pragmas 2
-   (magic 7 "AddI")) . .) ,21
+   (magic 7 "AddI")) . .) ,29
  (template 9 :foobar.0.tge6t2h7f . . . 15
   (params) . . . 2,1
   (stmts 
-   (break .))) ,24
+   (break .))) ,32
  (proc 5 :foo.0.tge6t2h7f . . . 8
   (params 1
-   (param :x.1 . . ~7,~23
+   (param :x.1 . . ~7,~31
     (i -1) .) 9
-   (param :y.1 . . ~15,~20
-    (string) .)) 2,~23
+   (param :y.1 . . ~15,~28
+    (string) .)) 2,~31
   (i -1) . . 2,1
   (stmts 4
-   (result :result.0 . . ~4,~24
+   (result :result.0 . . ~4,~32
     (i -1) .) 4
    (var :x.2 . .
     (string) 4 "abc") 7,1
    (asgn ~7 result.0 2 +4) 2,2
    (asgn ~2 x.2 2 "34") ~2,~1
-   (ret result.0))) ,29
+   (ret result.0))) ,37
  (proc 5 :overloaded.0.tge6t2h7f . . . 15
   (params) . . . 2,1
   (stmts 4
-   (let :someInt.0 . . ~4,~29
+   (let :someInt.0 . . ~4,~37
     (i -1) 13
     (add
      (i -1) 1 +23 5 +90)) ,1
    (discard 11
     (call ~3 foo.0.tge6t2h7f 3
      (add
-      (i -1) ~2 +34 1 +56) 8 "xyz")))) 19,13
+      (i -1) ~2 +34 1 +56) 8 "xyz")))) 19,21
  (type :MyGeneric.1.tge6t2h7f . 
-  (at MyGeneric.0.tge6t2h7f ~17,~12
+  (at MyGeneric.0.tge6t2h7f ~17,~20
    (i -1)) ~4,~4 . ~2,~4
   (object . ~13,1
-   (fld :x.1.tge6t2h7f . . ~2,~9
-    (i -1) .))) 18,14
+   (fld :x.1.tge6t2h7f . . ~2,~17
+    (i -1) .))) 18,22
  (type :MyGeneric.2.tge6t2h7f . 
-  (at MyGeneric.0.tge6t2h7f ~16,~11
+  (at MyGeneric.0.tge6t2h7f ~16,~19
    (f +64)) ~3,~5 . ~1,~5
   (object . ~13,1
-   (fld :x.2.tge6t2h7f . . ~2,~7
+   (fld :x.2.tge6t2h7f . . ~2,~15
     (f +64) .))))

--- a/src/nimony/tests/basics/tgeneric_obj.nim
+++ b/src/nimony/tests/basics/tgeneric_obj.nim
@@ -4,8 +4,16 @@ type
                               ## architecture, but is always the same as a pointer.
   float* {.magic: Float.}
   string* {.magic: String.}
+  uint8* {.magic: UInt8.}
 
+  set*[T] {.magic: Set.}
   array* [Index, T] {.magic: Array.}
+
+var myset: set[uint8]
+var myarr: array[3, int]
+let u8 = 3'u8
+myset = {1'u8, u8, 5'u8, 7'u8..9'u8}
+myarr = [1, 2, 3]
 
 type
   MyGeneric[T] = object


### PR DESCRIPTION
Magic types like `array`, `set` are constructed with the same syntax as regular generic invocations, so they need special handling in `semInvoke`. In the case of `array`, the order of the children differs between the invocation and the NIF tag, so the magic type is built after the arguments have been processed.

If necessary the output could also be saved into a symbol (`targetSym`) and put in the instantiation cache but this isn't done for now. Also, if any type arguments are generic then it stays as an `InvokeT` and isn't inlined into a magic, this could be changed as well since it's not the case for compound types that aren't invoked magics, i.e. proc types, tuples.

There was a bug in `linearMatch`, every use of it expects the starting ParLe to be encountered inside the `linearMatch` call but linearMatch expects it to be skipped. So this is turned into an optional argument in case the previous use is needed in the future.

`AllowValues` also did not work for all node kinds in general i.e. int lits which is fixed.